### PR TITLE
Add German

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,35 +1,28 @@
-Developers
-==========
+## Developers
 
-* wereturtle <http://www.github.com/wereturtle>
+* [@wereturtle](https://github.com/wereturtle)
 
-Translations
-============
+## Translations
 
-* Russian - suhr
-* Portuguese (Brazil) - José Geraldo Gouvêa (jggouvea)
-* Italian - Tristano Ajmone (tajmone)
-* Japanese - piyo-gh
+* German - DHBWMAWHD ([@dhbwmawhd](https://github.com/dhbwmawhd))
+* Italian - Tristano Ajmone ([@tajmone](https://github.com/tajmone))
+* Japanese - piyo-gh ([@piyo-gh](https://github.com/piyo-gh))
+* Portuguese (Brazil) - José Geraldo Gouvêa ([@jggouvea](https://github.com/jggouvea))
+* Russian ([@suhr](https://github.com/suhr))
 
-Libraries
-=========
+## Libraries
 
-* Qt <http://www.qt.io/>
-* hunspell <http://hunspell.sourceforge.net/>
-* Sundown <http://github.com/vmg/sundown/>
+* [Qt](http://www.qt.io)
+* [hunspell](http://hunspell.sourceforge.net)
+* [Sundown](http://github.com/vmg/sundown)
 
-Reused Code
-===========
+## Reused Code
 
-* Graeme Gott, author of FocusWriter,
-  <http://gottcode.org/focuswriter/>
-* Dmitry Shachnev, author of Retext,
-  <http://sourceforge.net/p/retext/home/ReText/>
-* Gabriel M. Beddingfield, author of StretchPlayer,
-  <http://www.teuton.org/~gabriel/stretchplayer/>
+* Graeme Gott, author of [FocusWriter](http://gottcode.org/focuswriter)
+* Dmitry Shachnev, author of [Retext](http://sourceforge.net/p/retext/home/ReText)
+* Gabriel M. Beddingfield, author of [StretchPlayer](http://www.teuton.org/~gabriel/stretchplayer)
 
-Special Thanks
-==============
+## Special Thanks
 
 Graeme Gott, Dmitry Shachnev, and Gabriel M. Beddingfield were all indirectly my mentors in learning Qt by providing excellent code from which I could lift.
 

--- a/translations/ghostwriter_de.ts
+++ b/translations/ghostwriter_de.ts
@@ -1,0 +1,1591 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+<context>
+    <name>AbstractStatisticsWidget</name>
+    <message>
+        <location filename="../src/AbstractStatisticsWidget.cpp" line="26"/>
+        <source>&amp;lt; 1m</source>
+        <translation>&amp;lt; 1m</translation>
+    </message>
+    <message>
+        <location filename="../src/AbstractStatisticsWidget.cpp" line="27"/>
+        <source>&amp;lt; 1</source>
+        <translation>&amp;lt; 1</translation>
+    </message>
+    <message>
+        <location filename="../src/AbstractStatisticsWidget.cpp" line="28"/>
+        <source>250 words per page</source>
+        <translation>250 Wörter pro Seite</translation>
+    </message>
+    <message>
+        <location filename="../src/AbstractStatisticsWidget.cpp" line="65"/>
+        <source>%1h %2m</source>
+        <translation>%1Std %2Min</translation>
+    </message>
+    <message>
+        <location filename="../src/AbstractStatisticsWidget.cpp" line="69"/>
+        <source>%1m</source>
+        <translation>%1Min</translation>
+    </message>
+</context>
+<context>
+    <name>DictionaryDialog</name>
+    <message>
+        <location filename="../src/spelling/dictionary_dialog.cpp" line="36"/>
+        <source>Set Dictionary</source>
+        <translation>Wähle Wörterbuch</translation>
+    </message>
+</context>
+<context>
+    <name>DocumentManager</name>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="162"/>
+        <source>Open File</source>
+        <translation>Öffne Datei</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="177"/>
+        <source>Could not open %1</source>
+        <translation>Konnte %1 nicht öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="178"/>
+        <source>Permission denied.</source>
+        <translation>Zugriff verweigert</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="254"/>
+        <source>The document has been modified.</source>
+        <translation>Dieses Dokument wurde bearbeitet.</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="255"/>
+        <source>Discard changes?</source>
+        <translation>Änderungen verwerfen?</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="289"/>
+        <source>Rename File</source>
+        <translation>Datei umbenennen</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="304"/>
+        <source>Failed to rename %1</source>
+        <translation>%1 konnte nicht umbenannt werden</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="375"/>
+        <source>Save File</source>
+        <translation>Datei speichern</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="481"/>
+        <source>Error saving %1</source>
+        <translation>Fehler beim Speichern von %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="541"/>
+        <source>The document has been modified by another program.</source>
+        <translation>Dieses Dokument wurde von einem anderen Programm verändert.</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="542"/>
+        <source>Would you like to reload the document?</source>
+        <translation>Dokument nochmal neu laden?</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="599"/>
+        <location filename="../src/DocumentManager.cpp" line="656"/>
+        <source>Could not read %1</source>
+        <translation>Konnte %1 nicht lesen</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="614"/>
+        <source>opening %1</source>
+        <translation>öffne %1</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="754"/>
+        <source>File has been modified.</source>
+        <translation>Datei wurde bearbeitet.</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="758"/>
+        <source>%1 has been modified.</source>
+        <translation>%1 wurde bearbeitet.</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="767"/>
+        <source>Would you like to save your changes?</source>
+        <translation>Änderungen speichern?</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="803"/>
+        <source>%1 is read only.</source>
+        <translation>%1 kann nur gelesen werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="804"/>
+        <source>Overwrite protected file?</source>
+        <translation>Geschützte Datei überschreiben?</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="830"/>
+        <source>Overwrite failed.</source>
+        <translation>Überschreiben ist fehlgeschlagen.</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="831"/>
+        <source>Please save file to another location.</source>
+        <translation>Bitte Datei an einem anderen Ort speichern.</translation>
+    </message>
+</context>
+<context>
+    <name>DocumentStatisticsWidget</name>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="27"/>
+        <source>Very Easy</source>
+        <translation>Sehr leicht</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="28"/>
+        <source>Easy</source>
+        <translation>Leicht</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="29"/>
+        <source>Standard</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="30"/>
+        <source>Difficult</source>
+        <translation>Schwer</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="31"/>
+        <source>Very Difficult</source>
+        <translation>Sehr schwer</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="34"/>
+        <source>Words:</source>
+        <translation>Wörter:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="35"/>
+        <source>Characters:</source>
+        <translation>Zeichen:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="36"/>
+        <source>Sentences:</source>
+        <translation>Sätze:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="37"/>
+        <source>Paragraphs:</source>
+        <translation>Abschnitte:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="38"/>
+        <source>Pages:</source>
+        <translation>Seiten:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="39"/>
+        <source>Complex Words:</source>
+        <translation>Komplexe Wörter:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="40"/>
+        <source>Reading Time:</source>
+        <translation>Lesezeit:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="41"/>
+        <source>Reading Ease:</source>
+        <translation>Lesbarkeit:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="41"/>
+        <source>LIX Reading Ease</source>
+        <translation>LIX Lesbarkeitsindex</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="42"/>
+        <source>Grade Level:</source>
+        <translation>Stufe:</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="42"/>
+        <source>Coleman-Liau Readability Index (CLI)</source>
+        <translation>Coleman-Liau Lesbarkeits Index (CLI)</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="112"/>
+        <source>Kindergarten</source>
+        <translation>Kindergarten</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="116"/>
+        <source>Rocket Science</source>
+        <translation>Wissenschaft</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentStatisticsWidget.cpp" line="120"/>
+        <source>College</source>
+        <translation>Hochschule</translation>
+    </message>
+</context>
+<context>
+    <name>ExportDialog</name>
+    <message>
+        <location filename="../src/ExportDialog.cpp" line="49"/>
+        <source>Export</source>
+        <translation>Exportieren</translation>
+    </message>
+    <message>
+        <location filename="../src/ExportDialog.cpp" line="190"/>
+        <source>Smart Typography</source>
+        <translation>Smarte Typographie</translation>
+    </message>
+    <message>
+        <location filename="../src/ExportDialog.cpp" line="193"/>
+        <source>Export Options</source>
+        <translation>Export Optionen</translation>
+    </message>
+    <message>
+        <location filename="../src/ExportDialog.cpp" line="195"/>
+        <source>Markdown Converter:</source>
+        <translation>Markdown Konvertierer:</translation>
+    </message>
+    <message>
+        <location filename="../src/ExportDialog.cpp" line="238"/>
+        <source>exporting to %1</source>
+        <translation>exportiere nach %1</translation>
+    </message>
+    <message>
+        <location filename="../src/ExportDialog.cpp" line="255"/>
+        <source>Export failed.</source>
+        <translation>Export ist fehlgeschlagen.</translation>
+    </message>
+</context>
+<context>
+    <name>FindDialog</name>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="45"/>
+        <source>Search for:</source>
+        <translation>Suche nach:</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="47"/>
+        <source>Replace with:</source>
+        <translation>Ersetze mit:</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="51"/>
+        <source>Ignore case</source>
+        <translation>Groß- / Kleinschreibung ignorieren</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="52"/>
+        <source>Whole words only</source>
+        <translation>Nur ganze Wörter</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="53"/>
+        <source>Regular expressions</source>
+        <translation>Regulärer Ausdruck</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="56"/>
+        <source>Search up</source>
+        <translation>Suche weiter oben</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="57"/>
+        <source>Search down</source>
+        <translation>Suche weiter unten</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="64"/>
+        <source>&amp;Find</source>
+        <translation>&amp;Finde</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="68"/>
+        <source>&amp;Replace</source>
+        <translation>&amp;Ersetze</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="72"/>
+        <source>Replace &amp;All</source>
+        <translation>Ersetze &amp;Alle</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="134"/>
+        <source>Find</source>
+        <translation>Finde</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="142"/>
+        <source>Replace</source>
+        <translation>Ersetze</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="277"/>
+        <source>Question</source>
+        <translation>Frage</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/find_dialog.cpp" line="277"/>
+        <source>Replace %n instance(s)?</source>
+        <translation>
+            <numerusform>Ersetze %n gefundenes Beispiel?</numerusform>
+            <numerusform>Ersetze %n gefundene Beispiele?</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="281"/>
+        <location filename="../src/find_dialog.cpp" line="355"/>
+        <source>Sorry</source>
+        <translation>Entschuldigung</translation>
+    </message>
+    <message>
+        <location filename="../src/find_dialog.cpp" line="281"/>
+        <location filename="../src/find_dialog.cpp" line="355"/>
+        <source>Phrase not found.</source>
+        <translation>Ausdruck nicht gefunden.</translation>
+    </message>
+</context>
+<context>
+    <name>HtmlPreview</name>
+    <message>
+        <location filename="../src/HtmlPreview.cpp" line="70"/>
+        <source>HTML Preview</source>
+        <translation>HTML Vorschau</translation>
+    </message>
+    <message>
+        <location filename="../src/HtmlPreview.cpp" line="101"/>
+        <source>Copy HTML</source>
+        <translation>HTML kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/HtmlPreview.cpp" line="106"/>
+        <source>Export</source>
+        <translation>Exportieren</translation>
+    </message>
+    <message>
+        <location filename="../src/HtmlPreview.cpp" line="111"/>
+        <source>Print</source>
+        <translation>Drucken</translation>
+    </message>
+    <message>
+        <location filename="../src/HtmlPreview.cpp" line="123"/>
+        <source>No markdown (pandoc, multimarkdown, discount) processors are installed. Please install or add their installation locations to your system PATH environment variable.</source>
+        <translation>Keine Markdown (Pandoc, MultiMarkdown, Discount) Processoren installiert. Bitte installiern und / oder die Installationspfade zu den Systemumgebungsvariablen (PATH) hinzufügen.</translation>
+    </message>
+    <message>
+        <location filename="../src/HtmlPreview.cpp" line="151"/>
+        <source>Github (Default)</source>
+        <translation>Github (Standard)</translation>
+    </message>
+    <message>
+        <location filename="../src/HtmlPreview.cpp" line="170"/>
+        <source>Add/Remove Custom Style Sheets...</source>
+        <translation>Hinzufügen / Löschen von eigenen Stilen...</translation>
+    </message>
+</context>
+<context>
+    <name>ImageButton</name>
+    <message>
+        <location filename="../src/image_button.cpp" line="90"/>
+        <source>Open Image</source>
+        <translation>Bild öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/image_button.cpp" line="90"/>
+        <source>Images(%1)</source>
+        <translation>Bilder (%1)</translation>
+    </message>
+</context>
+<context>
+    <name>LocaleDialog</name>
+    <message>
+        <location filename="../src/LocaleDialog.cpp" line="37"/>
+        <source>Set Application Language</source>
+        <translation>Wähle Sprache für das Programm</translation>
+    </message>
+    <message>
+        <location filename="../src/LocaleDialog.cpp" line="48"/>
+        <source>The translations folder is missing.</source>
+        <translation>Der Übersetzungsordner konnte nicht gefunden werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/LocaleDialog.cpp" line="49"/>
+        <source>Please reinstall this application for more language options.</source>
+        <translation>Bitte installiere dieses Programm erneut für weitere Sprachoptionen.</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="107"/>
+        <source>Outline</source>
+        <translation>Übersicht</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="120"/>
+        <source># Heading 1</source>
+        <translation># Überschrift 1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="121"/>
+        <source>## Heading 2</source>
+        <translation>## Überschrift 2</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="122"/>
+        <source>### Heading 3</source>
+        <translation>### Überschrift 3</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="123"/>
+        <source>#### Heading 4</source>
+        <translation>#### Überschrift 4</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="124"/>
+        <source>##### Heading 5</source>
+        <translation>##### Überschrift 5</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="125"/>
+        <source>###### Heading 6</source>
+        <translation>###### Überschrift 6</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="126"/>
+        <source>*Emphasis* _Emphasis_</source>
+        <translation>*Hervorhebung* _Hervorhebung_</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="127"/>
+        <source>**Strong** __Strong__</source>
+        <translation>**Kräftig** __Kräftig__</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="128"/>
+        <source>1. Numbered List</source>
+        <translation>1. Nummerierte Liste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="129"/>
+        <source>* Bullet List</source>
+        <translation>* Stichpunkt Liste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="130"/>
+        <source>+ Bullet List</source>
+        <translation>+ Stichpunkt Liste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="131"/>
+        <source>- Bullet List</source>
+        <translation>- Stichpunkt Liste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="132"/>
+        <source>&gt; Block Quote</source>
+        <translation>&gt; Blockzitat</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="133"/>
+        <source>`Code Span`</source>
+        <translation>`Code im Fließtext`</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="134"/>
+        <source>``` Code Block</source>
+        <translation>``` Code Block</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="136"/>
+        <source>[Reference Link][ID]</source>
+        <translation>[Referenzlink][ID]</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="138"/>
+        <source>![Image][./image.jpg &quot;Title&quot;]</source>
+        <translation>![Bild][./bild.jpg &quot;Titel&quot;]</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="139"/>
+        <source>--- *** ___ Horizontal Rule</source>
+        <translation>--- *** ___ Horizontaler Strich</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="142"/>
+        <source>Cheat Sheet</source>
+        <translation>Kurzreferenz</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="799"/>
+        <source>Insert Image</source>
+        <translation>Bild einfügen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="802"/>
+        <source>Images</source>
+        <translation>Bilder</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="803"/>
+        <source>All Files</source>
+        <translation>Alle Dateien</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="840"/>
+        <source>Tabulation Width</source>
+        <translation>Breite der Einrückung</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="841"/>
+        <source>Spaces</source>
+        <translation>Leerzeichen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="898"/>
+        <source>Failed to open Quick Reference Guide.</source>
+        <translation>Konnte Kurzreferenz nicht öffnen.</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="914"/>
+        <source>Quick Reference Guide</source>
+        <translation>Kurzreferenz</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="978"/>
+        <source>&lt;p&gt;Copyright &amp;copy; 2014-2016 wereturtle&lt;/b&gt;&lt;p&gt;You may use and redistribute this software under the terms of the &lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;GNU General Public License Version 3&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Visit the official website at &lt;a href=&quot;http://github.com/wereturtle/ghostwriter&quot;&gt;http://github.com/wereturtle/ghostwriter&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Special thanks and credit for reused code goes to&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;mailto:graeme@gottcode.org&quot;&gt;Graeme Gott&lt;/a&gt;, author of &lt;a href=&quot;http://gottcode.org/focuswriter/&quot;&gt;FocusWriter&lt;/a&gt;&lt;br/&gt;Dmitry Shachnev, author of &lt;a href=&quot;http://sourceforge.net/p/retext/home/ReText/&quot;&gt;Retext&lt;/a&gt;&lt;br/&gt;&lt;a href=&quot;mailto:gabriel@teuton.org&quot;&gt;Gabriel M. Beddingfield&lt;/a&gt;, author of &lt;a href=&quot;http://www.teuton.org/~gabriel/stretchplayer/&quot;&gt;StretchPlayer&lt;/a&gt;&lt;br/&gt;&lt;p&gt;I am also deeply indebted to &lt;a href=&quot;mailto:w.vollprecht@gmail.com&quot;&gt;Wolf Vollprecht&lt;/a&gt;, the author of &lt;a href=&quot;http://uberwriter.wolfvollprecht.de/&quot;&gt;UberWriter&lt;/a&gt;, for the inspiration he provided in creating such a beautiful Markdown editing tool.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Copyright &amp;copy; 2014-2016 wereturtle&lt;/b&gt;&lt;p&gt;You may use and redistribute this software under the terms of the &lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;GNU General Public License Version 3&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Visit the official website at &lt;a href=&quot;http://github.com/wereturtle/ghostwriter&quot;&gt;http://github.com/wereturtle/ghostwriter&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Special thanks and credit for reused code goes to&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;mailto:graeme@gottcode.org&quot;&gt;Graeme Gott&lt;/a&gt;, author of &lt;a href=&quot;http://gottcode.org/focuswriter/&quot;&gt;FocusWriter&lt;/a&gt;&lt;br/&gt;Dmitry Shachnev, author of &lt;a href=&quot;http://sourceforge.net/p/retext/home/ReText/&quot;&gt;Retext&lt;/a&gt;&lt;br/&gt;&lt;a href=&quot;mailto:gabriel@teuton.org&quot;&gt;Gabriel M. Beddingfield&lt;/a&gt;, author of &lt;a href=&quot;http://www.teuton.org/~gabriel/stretchplayer/&quot;&gt;StretchPlayer&lt;/a&gt;&lt;br/&gt;&lt;p&gt;I am also deeply indebted to &lt;a href=&quot;mailto:w.vollprecht@gmail.com&quot;&gt;Wolf Vollprecht&lt;/a&gt;, the author of &lt;a href=&quot;http://uberwriter.wolfvollprecht.de/&quot;&gt;UberWriter&lt;/a&gt;, for the inspiration he provided in creating such a beautiful Markdown editing tool.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1001"/>
+        <source>About %1</source>
+        <translation>Über %1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1175"/>
+        <source>Please restart the application for changes to take effect.</source>
+        <translation>Bitte starte das Programm neu, damit die Änderungen wirksam werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1187"/>
+        <source>Hud Window Opacity</source>
+        <translation>HUD Fenster Deckkraft</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1225"/>
+        <source>Matched Characters</source>
+        <translation>Übereinstimmende Zeichen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1345"/>
+        <source>&amp;File</source>
+        <translation>&amp;Datei</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1347"/>
+        <source>&amp;New</source>
+        <translation>&amp;Neu</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1348"/>
+        <source>&amp;Open</source>
+        <translation>&amp;Öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1351"/>
+        <source>Reopen Closed File</source>
+        <translation>Geschlossene Datei wieder öffnen.</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1360"/>
+        <source>Clear Menu</source>
+        <translation>Liste geöffneter Dateien löschen.</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1365"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Speichern</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1366"/>
+        <source>Save &amp;As...</source>
+        <translation>Speichern &amp;Als...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1350"/>
+        <source>Open &amp;Recent...</source>
+        <translation>Öffne &amp;kürzlich geöffnete Dateien...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="135"/>
+        <source>[Link](http://url.com &quot;Title&quot;)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="137"/>
+        <source>[ID]: http://url.com &quot;Reference Definition&quot;</source>
+        <translation>[ID]: http://url.com &quot;Titel für Link&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="152"/>
+        <source>Document Statistics</source>
+        <translation>Dokument Statistiken</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="162"/>
+        <source>Session Statistics</source>
+        <translation>Session Statistiken</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/MainWindow.cpp" line="1006"/>
+        <source>%Ln word(s)</source>
+        <translation>
+            <numerusform>%Ln word</numerusform>
+            <numerusform>%Ln words</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1367"/>
+        <source>R&amp;ename...</source>
+        <translation>&amp;Umbenennen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1368"/>
+        <source>Re&amp;load from Disk...</source>
+        <translation>Nochmal &amp;laden...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1370"/>
+        <source>Print Pre&amp;view</source>
+        <translation>Druck&amp;vorschau</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1371"/>
+        <source>&amp;Print</source>
+        <translation>&amp;Drucken</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1373"/>
+        <source>&amp;Export</source>
+        <translation>&amp;Exportieren</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1375"/>
+        <source>&amp;Quit</source>
+        <translation>&amp;Schließen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1377"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1378"/>
+        <source>&amp;Undo</source>
+        <translation>&amp;Rückgängig</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1379"/>
+        <source>&amp;Redo</source>
+        <translation>&amp;Wiederholen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1381"/>
+        <source>Cu&amp;t</source>
+        <translation>Aus&amp;schneiden</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1382"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1383"/>
+        <source>&amp;Paste</source>
+        <translation>&amp;Einfügen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1385"/>
+        <source>&amp;Insert Image...</source>
+        <translation>&amp;Bild einfügen...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1387"/>
+        <source>&amp;Find</source>
+        <translation>&amp;Finden</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1388"/>
+        <source>Rep&amp;lace</source>
+        <translation>&amp;Ersetzen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1390"/>
+        <source>&amp;Spell check</source>
+        <translation>&amp;Rechtschreibung prüfen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1392"/>
+        <source>For&amp;mat</source>
+        <translation>Format</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1393"/>
+        <source>&amp;Bold</source>
+        <translation>Fett</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1394"/>
+        <source>&amp;Italic</source>
+        <translation>Kursiv</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1395"/>
+        <source>Stri&amp;kthrough</source>
+        <translation>Durchgestrichen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1396"/>
+        <source>&amp;HTML Comment</source>
+        <translation>HTML Kommentar</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1398"/>
+        <source>I&amp;ndent</source>
+        <translation>Einrückung</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1399"/>
+        <source>&amp;Unindent</source>
+        <translation>Ausrücken</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1401"/>
+        <source>Block &amp;Quote</source>
+        <translation>Blockzitat</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1402"/>
+        <source>&amp;Strip Block Quote</source>
+        <translation>Blockzitat entfernen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1404"/>
+        <source>&amp;* Bullet List</source>
+        <translation>&amp;* Stichpunkliste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1405"/>
+        <source>&amp;- Bullet List</source>
+        <translation>&amp;- Stichpunkliste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1406"/>
+        <source>&amp;+ Bullet List</source>
+        <translation>&amp;+ Stichpunktliste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1408"/>
+        <source>1&amp;. Numbered List</source>
+        <translation>1&amp;. Nummerierte Liste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1409"/>
+        <source>1&amp;) Numbered List</source>
+        <translation>1&amp;) Nummerierte Liste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1411"/>
+        <source>&amp;Task List</source>
+        <translation>Aufgabenliste</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1412"/>
+        <source>Toggle Task(s) &amp;Complete</source>
+        <translation>Umschalter Aufgaben erledigt</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1414"/>
+        <source>&amp;View</source>
+        <translation>Ansicht</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1416"/>
+        <source>&amp;Full Screen</source>
+        <translation>Vollbild</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1423"/>
+        <source>&amp;Preview in HTML</source>
+        <translation>HTML Vorschau</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1424"/>
+        <source>&amp;Outline HUD</source>
+        <translation>Übersicht HUD</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1425"/>
+        <source>&amp;Cheat Sheet HUD</source>
+        <translation>Kurzreferenz HUD</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1426"/>
+        <source>&amp;Document Statistics HUD</source>
+        <translation>Dokument Statistiken HUD</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1427"/>
+        <source>&amp;Session Statistics HUD</source>
+        <translation>Session Statistiken HUD</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1430"/>
+        <source>&amp;Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1431"/>
+        <source>Themes...</source>
+        <translation>Themes...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1432"/>
+        <source>Font...</source>
+        <translation>Font...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1434"/>
+        <source>Focus Mode</source>
+        <translation>Fokus Modus</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1439"/>
+        <source>Sentence</source>
+        <translation>Satz</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1445"/>
+        <source>Current Line</source>
+        <translation>Aktuelle Zeile</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1451"/>
+        <source>Three Lines</source>
+        <translation>Drei Zeilen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1457"/>
+        <source>Paragraph</source>
+        <translation>Absatz</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1470"/>
+        <source>Editor Width</source>
+        <translation>Editor Breite</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1474"/>
+        <source>Narrow</source>
+        <translation>Eng</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1480"/>
+        <source>Medium</source>
+        <translation>Mittel</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1486"/>
+        <source>Wide</source>
+        <translation>Breit</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1492"/>
+        <source>Full</source>
+        <translation>Voll</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1505"/>
+        <source>Blockquote Style</source>
+        <translation>Blockzitat Stil</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1509"/>
+        <source>Plain</source>
+        <translation>Schlicht</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1515"/>
+        <source>Italic</source>
+        <translation>Kursiv</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1521"/>
+        <source>Fancy</source>
+        <translation>Extravagant</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1534"/>
+        <source>Hide menu bar in full screen mode</source>
+        <translation>Menüleiste im Vollbildmodus verstecken</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1541"/>
+        <source>Use Large Headings</source>
+        <translation>Große Überschriften verwenden</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1548"/>
+        <source>Use Underline Instead of Italics for Emphasis</source>
+        <translation>Benutze Unterstrich statt Kursivschrift zur Hervorhebung</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1555"/>
+        <source>Automatically Match Characters while Typing</source>
+        <translation>Zeichen automatisch beim Tippen gruppieren</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1561"/>
+        <source>Customize Matched Characters...</source>
+        <translation>Gruppierte Zeichen anpassen...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1564"/>
+        <source>Cycle Bullet Point Markers</source>
+        <translation>Aufzählungszeichen abwechseln</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1571"/>
+        <source>Display Current Time in Full Screen Mode</source>
+        <translation>Aktuelle Zeit im Vollbild Modus anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1579"/>
+        <source>Live Spellcheck Enabled</source>
+        <translation>Live Rechtschreibprüfung aktiviert</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1585"/>
+        <source>Dictionaries...</source>
+        <translation>Wörterbücher</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1587"/>
+        <source>Application Language...</source>
+        <translation>Programmsprache...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1591"/>
+        <source>Remember File History</source>
+        <translation>Geöffnete Dateien merken</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1597"/>
+        <source>Auto Save</source>
+        <translation>Automatisch speichern</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1603"/>
+        <source>Backup File on Save</source>
+        <translation>Beim Speichern ein Backup machen</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1612"/>
+        <source>Insert Spaces for Tabs</source>
+        <translation>Leerzeichen statt Tabulatoren verwenden</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1619"/>
+        <source>Tabulation Width...</source>
+        <translation>Tabulatorbreite...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1624"/>
+        <source>Alternate Row Colors in HUD Windows</source>
+        <translation>Zeilenfarben im HUD Fenster abwechseln</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1634"/>
+        <source>HUD Window Button Layout</source>
+        <translation>Layout der Knöpfe im HUD Fenster</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1638"/>
+        <source>Left</source>
+        <translation>Links</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1644"/>
+        <source>Right</source>
+        <translation>Rechts</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1655"/>
+        <source>Enable Desktop Compositing Effects</source>
+        <translation>Effekte für die Generierung aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1665"/>
+        <source>HUD Window Opacity...</source>
+        <translation>HUD Fenster Deckkraft</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1667"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Hilfe</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1668"/>
+        <source>&amp;About</source>
+        <translation>&amp;Über</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1669"/>
+        <source>About &amp;Qt</source>
+        <translation>Über &amp;Qt</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1670"/>
+        <source>Quick &amp;Reference Guide</source>
+        <translation>Kurzreferenz</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1715"/>
+        <source>Hemingway</source>
+        <translation>Hemingway</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1717"/>
+        <source>Toggle Hemingway mode</source>
+        <translation>Umschalter Hemingway Modus</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1722"/>
+        <source>Focus</source>
+        <translation>Fokus</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1724"/>
+        <source>Toggle distraction free mode</source>
+        <translation>Umschalter Ablenkungsfreier Modus</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow.cpp" line="1732"/>
+        <source>Toggle full screen mode</source>
+        <translation>Umschalter Vollbild</translation>
+    </message>
+</context>
+<context>
+    <name>MarkdownEditor</name>
+    <message>
+        <location filename="../src/MarkdownEditor.cpp" line="119"/>
+        <source>Add word to dictionary</source>
+        <translation>Wort zu Wörterbuch hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/MarkdownEditor.cpp" line="120"/>
+        <source>Check spelling...</source>
+        <translation>Rechtschreibung prüfen...</translation>
+    </message>
+    <message>
+        <location filename="../src/MarkdownEditor.cpp" line="571"/>
+        <source>No spelling suggestions found</source>
+        <translation>Keine Vorschläge für Schreibweise gefunden</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/CommandLineExporter.cpp" line="92"/>
+        <location filename="../src/CommandLineExporter.cpp" line="96"/>
+        <source>Export failed: </source>
+        <translation>Export fehlgeschlagen:</translation>
+    </message>
+    <message>
+        <location filename="../src/CommandLineExporter.cpp" line="114"/>
+        <source>%1 format is not supported by this processor.</source>
+        <translation>Format %1 konnte mit der aktuellen Auswahl nicht verarbeitet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/CommandLineExporter.cpp" line="122"/>
+        <source>Failed to execute command: </source>
+        <translation>Folgender Befehl konnte nicht ausgeführt werden: </translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="52"/>
+        <source>Markdown</source>
+        <translation>Markdown</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="53"/>
+        <source>Text</source>
+        <translation>Text</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="54"/>
+        <source>All</source>
+        <translation>Alle</translation>
+    </message>
+    <message>
+        <location filename="../src/DocumentManager.cpp" line="859"/>
+        <source>Null or empty file path provided for writing.</source>
+        <translation>Null oder kein Pfad beim Schreibversuch gegeben.</translation>
+    </message>
+    <message>
+        <location filename="../src/Exporter.cpp" line="66"/>
+        <source>Export to HTML is not supported with this processor.</source>
+        <translation>HTML Export konnte mit der aktuellen Auswahl nicht durchgeführt werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/SundownExporter.cpp" line="127"/>
+        <source>%1 format is unsupported by the Sundown processor.</source>
+        <translation>Das %1 Format unterstützt Sundown nicht.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="147"/>
+        <source>The specified theme does not exist in the file system: </source>
+        <translation>Das ausgewählte Theme existiert nicht: </translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="252"/>
+        <source>The specified theme is not available. Try restarting the application. If problem persists, please file a bug report.</source>
+        <translation>Das ausgewählte Theme ist nicht verfügbar. Programm erneut starten. Sollte der Fehler weiterhin bestehen, bitte den Fehler den Entwicklern melden.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="322"/>
+        <source>Could not delete %1 from theme. Please try setting the theme file permissions to be writeable.</source>
+        <translation>Konnte %1 nicht vom Theme löschen. Es sollte überprüfet werden, ob die Zieldatei beschrieben werden darf.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="345"/>
+        <source>&apos;%1&apos; already exists. Please choose another name.</source>
+        <translation>&apos;%1&apos; existiert bereits. Bitte einen anderen Namen wählen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="355"/>
+        <source>&apos;%1&apos; theme already exists. Please choose another name.</source>
+        <translation>&apos;%1&apos; Theme existiert bereits. Bitte einen anderen Namen wählen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="390"/>
+        <source>Failed to rename theme. Please check file permissions.</source>
+        <translation>Konnte Theme nicht umbenennen. Bitte überprüfen, ob die Zieldatei beschrieben werden darf.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="435"/>
+        <source>Theme is read-only. Please try renaming the theme, or setting the theme file to be writable.</source>
+        <translation>Theme Datei ist nur lesbar. Bitte Zieldatei umbenennen, oder wahlweise beschreibbar machen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="472"/>
+        <source>Failed to remove old theme image. Please check file permissions.</source>
+        <translation>Konnte Bild von altem Theme nicht entfernen. Bitte Recht für Zieldatei überprüfen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="504"/>
+        <source>The old theme image file could not be removed from the theme directory. Please check file permissions.</source>
+        <translation>Das alte Bild vom Theme konnte nicht aus dessen Ordner entfernt werden. Bitte Rechte für Zieldatei überprüfen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="516"/>
+        <source>Theme image file could not be copied to the theme directory. Please check file permissions.</source>
+        <translation>Bilddatei für Theme konnte nicht in den Zielordner kopiert werden. Bitte Recht für Zieldatei überprüfen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="535"/>
+        <source>Theme could not be saved to disk. Please check file permissions or try renaming the theme.</source>
+        <translation>Theme konnte nicht gespeichert werden. Bitte Rechte für Zieldatei prüfen oder diese umbenennen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="560"/>
+        <source>Untitled 1</source>
+        <translation>Unbenannt 1</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="573"/>
+        <source>Untitled %1</source>
+        <translation>Unbenannt %1</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="629"/>
+        <location filename="../src/ThemeFactory.cpp" line="651"/>
+        <location filename="../src/ThemeFactory.cpp" line="679"/>
+        <source>Invalid or missing value for %1 provided.</source>
+        <translation>Ungültiger oder fehlender Wert für %1 gegeben.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeFactory.cpp" line="659"/>
+        <source>Value for %1 is out of range. Valid values are between %2 and %3, inclusive.</source>
+        <translation>Wert für %1 ist nicht im gültigen Bereich. Gültige Werte liegen im Bereich inklusiven Grenzen %2 und %3.</translation>
+    </message>
+</context>
+<context>
+    <name>SessionStatisticsWidget</name>
+    <message>
+        <location filename="../src/SessionStatisticsWidget.cpp" line="25"/>
+        <source>Words Written:</source>
+        <translation>Geschriebene Wörter:</translation>
+    </message>
+    <message>
+        <location filename="../src/SessionStatisticsWidget.cpp" line="26"/>
+        <source>Pages Written:</source>
+        <translation>Geschriebene Seiten:</translation>
+    </message>
+    <message>
+        <location filename="../src/SessionStatisticsWidget.cpp" line="27"/>
+        <source>Average WPM:</source>
+        <translation>Durchschnitt Wörter pro Minute:</translation>
+    </message>
+    <message>
+        <location filename="../src/SessionStatisticsWidget.cpp" line="28"/>
+        <source>Total Time:</source>
+        <translation>Zeit insgesamt:</translation>
+    </message>
+    <message>
+        <location filename="../src/SessionStatisticsWidget.cpp" line="29"/>
+        <source>Idle Time:</source>
+        <translation>Ungenutze Zeit</translation>
+    </message>
+</context>
+<context>
+    <name>SimpleFontDialog</name>
+    <message>
+        <location filename="../src/SimpleFontDialog.cpp" line="44"/>
+        <source>Family</source>
+        <translation>Familie</translation>
+    </message>
+    <message>
+        <location filename="../src/SimpleFontDialog.cpp" line="72"/>
+        <source>Size</source>
+        <translation>Größe</translation>
+    </message>
+    <message>
+        <location filename="../src/SimpleFontDialog.cpp" line="75"/>
+        <source>AaBbCcXxYyZz</source>
+        <translation>AaBbCcXxYyZz</translation>
+    </message>
+    <message>
+        <location filename="../src/SimpleFontDialog.cpp" line="79"/>
+        <source>Preview</source>
+        <translation>Vorschau</translation>
+    </message>
+</context>
+<context>
+    <name>SpellChecker</name>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="139"/>
+        <source>Check Spelling</source>
+        <translation>Rechtschreibung prüfen</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="147"/>
+        <source>&amp;Add</source>
+        <translation>Hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="150"/>
+        <source>&amp;Ignore</source>
+        <translation>Ignorieren</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="153"/>
+        <source>I&amp;gnore All</source>
+        <translation>Alle ignorieren</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="158"/>
+        <source>&amp;Change</source>
+        <translation>Ändern</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="161"/>
+        <source>C&amp;hange All</source>
+        <translation>Alle ändern</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="176"/>
+        <source>Not in dictionary:</source>
+        <translation>Nicht im Wörterbuch:</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="184"/>
+        <source>Change to:</source>
+        <translation>Ändern nach:</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="200"/>
+        <source>Checking spelling...</source>
+        <translation>Rechtschreibung prüfen...</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="200"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="201"/>
+        <source>Please wait</source>
+        <translation>Bitte warten</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="228"/>
+        <source>Continue checking at beginning of file?</source>
+        <translation>Rechtschreibung weiter ab Dokumentbeginn prüfen?</translation>
+    </message>
+    <message>
+        <location filename="../src/spelling/spell_checker.cpp" line="287"/>
+        <source>Spell check complete.</source>
+        <translation>Prüfung der Rechtschreibung abgeschlossen.</translation>
+    </message>
+</context>
+<context>
+    <name>StyleSheetManagerDialog</name>
+    <message>
+        <location filename="../src/StyleSheetManagerDialog.cpp" line="38"/>
+        <source>Custom Style Sheets</source>
+        <translation>Eigene Stile</translation>
+    </message>
+    <message>
+        <location filename="../src/StyleSheetManagerDialog.cpp" line="65"/>
+        <source>Add new style sheet</source>
+        <translation>Neuen Stil hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/StyleSheetManagerDialog.cpp" line="67"/>
+        <source>Remove selected style sheet(s) from list. (No files will be deleted from the hard disk.)</source>
+        <translation>Ausgewählte Stile von der Liste entfernen. (Es werden keine Dateien vom System gelöscht)</translation>
+    </message>
+    <message>
+        <location filename="../src/StyleSheetManagerDialog.cpp" line="113"/>
+        <source>Select CSS File</source>
+        <translation>Stildatei auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/StyleSheetManagerDialog.cpp" line="115"/>
+        <source>CSS</source>
+        <translation>CSS</translation>
+    </message>
+    <message>
+        <location filename="../src/StyleSheetManagerDialog.cpp" line="115"/>
+        <source>All</source>
+        <translation>Alle</translation>
+    </message>
+    <message>
+        <location filename="../src/StyleSheetManagerDialog.cpp" line="144"/>
+        <source>Don&apos;t worry! No files will be deleted from the hard disk. But are you sure you wish to remove the selected style sheet(s) from the list?</source>
+        <translation>Keine Angst, ausgewählte Stile werden nicht vom System gelöscht. Sollten sie dennoch von dieser Liste gelöscht werden?</translation>
+    </message>
+</context>
+<context>
+    <name>TextDocument</name>
+    <message>
+        <location filename="../src/TextDocument.cpp" line="36"/>
+        <location filename="../src/TextDocument.cpp" line="68"/>
+        <source>untitled</source>
+        <translation>unbenannt</translation>
+    </message>
+</context>
+<context>
+    <name>ThemeEditorDialog</name>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="40"/>
+        <source>Edit Theme</source>
+        <translation>Theme bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="98"/>
+        <source>Rounded</source>
+        <translation>Rund</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="99"/>
+        <source>Square</source>
+        <translation>Eckig</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="103"/>
+        <location filename="../src/ThemeEditorDialog.cpp" line="111"/>
+        <source>Stretch</source>
+        <translation>Gestreckt</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="104"/>
+        <location filename="../src/ThemeEditorDialog.cpp" line="110"/>
+        <source>Center</source>
+        <translation>Zentriert</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="108"/>
+        <source>None</source>
+        <translation>Kein</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="109"/>
+        <source>Tile</source>
+        <translation>Kachel</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="112"/>
+        <source>Scale</source>
+        <translation>Maßstab</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="113"/>
+        <source>Zoom</source>
+        <translation>Zoom</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="124"/>
+        <source>Theme Name</source>
+        <translation>Theme Name</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="137"/>
+        <source>Text Color</source>
+        <translation>Textfarbe</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="138"/>
+        <source>Markup Color</source>
+        <translation>Markup Farbe</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="139"/>
+        <source>Link Color</source>
+        <translation>Linkfarbe</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="140"/>
+        <source>Spelling Error Color</source>
+        <translation>Rechtschreibfehlerfarbe</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="141"/>
+        <source>Text Area Background Color</source>
+        <translation>Textbereich Hintergrundfarbe</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="144"/>
+        <source>Text Editor</source>
+        <translation>Text Editor</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="150"/>
+        <source>Background Image</source>
+        <translation>Hintergrundbild</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="151"/>
+        <source>Background Color</source>
+        <translation>Hintergrundfarbe</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="153"/>
+        <source>Editor Aspect</source>
+        <translation>Editor Seitenverhältnis</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="154"/>
+        <source>Editor Corners</source>
+        <translation>Editorecken</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="155"/>
+        <source>Editor Opacity</source>
+        <translation>Editor Deckkraft</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="158"/>
+        <source>Background</source>
+        <translation>Hintergrund</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="164"/>
+        <source>HUD Foreground Color</source>
+        <translation>HUD Vordergrundfarbe</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="165"/>
+        <source>HUD Background Color</source>
+        <translation>HUD Hintergrundfarbe</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="168"/>
+        <source>HUD</source>
+        <translation>HUD</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="247"/>
+        <source>Unable to save theme.</source>
+        <translation>Konnte Theme nicht speichern.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeEditorDialog.cpp" line="265"/>
+        <source>Failed to rename theme.</source>
+        <translation>Konnte Theme nicht umbenennen.</translation>
+    </message>
+</context>
+<context>
+    <name>ThemeSelectionDialog</name>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="50"/>
+        <source>Themes</source>
+        <translation>Themes</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="96"/>
+        <source>Edit...</source>
+        <translation>Bearbeiten...</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="158"/>
+        <source>Unable to load theme.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="239"/>
+        <source>Cannot delete theme.</source>
+        <translation>Konnte Theme nicht löschen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="240"/>
+        <source>Sorry, this is a built-in theme that cannot be deleted.</source>
+        <translation>Entschuldingung, dieser Standard-Theme kann nicht gelöscht werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="251"/>
+        <source>Are you sure you want to permanently delete the &apos;%1&apos; theme?</source>
+        <translation>Soll der &apos;%1&apos; Theme wirklich gelöscht werden?</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="269"/>
+        <source>Failed to delete theme.</source>
+        <translation>Konnte Theme nicht löschen.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="300"/>
+        <source>Cannot edit theme.</source>
+        <translation>Kann Theme nicht bearbeiten.</translation>
+    </message>
+    <message>
+        <location filename="../src/ThemeSelectionDialog.cpp" line="301"/>
+        <source>Sorry, this is a built-in theme that cannot be edited.</source>
+        <translation>Dieser Standard-Theme kann nicht bearbeitet werden.</translation>
+    </message>
+</context>
+</TS>

--- a/translations/ghostwriter_en.ts
+++ b/translations/ghostwriter_en.ts
@@ -384,7 +384,7 @@
     </message>
     <message>
         <location filename="../src/HtmlPreview.cpp" line="123"/>
-        <source>No markdown (pandoc, multimarkdown, discount) processors are installed.  Please install or add their installation locations to your system PATH environment variable.</source>
+        <source>No markdown (pandoc, multimarkdown, discount) processors are installed. Please install or add their installation locations to your system PATH environment variable.</source>
         <translation></translation>
     </message>
     <message>
@@ -1163,52 +1163,52 @@
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="252"/>
-        <source>The specified theme is not available.  Try restarting the application.  If problem persists, please file a bug report.</source>
+        <source>The specified theme is not available. Try restarting the application. If problem persists, please file a bug report.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="322"/>
-        <source>Could not delete %1 from theme.  Please try setting the theme file permissions to be writeable.</source>
+        <source>Could not delete %1 from theme. Please try setting the theme file permissions to be writeable.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="345"/>
-        <source>&apos;%1&apos; already exists.  Please choose another name.</source>
+        <source>&apos;%1&apos; already exists. Please choose another name.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="355"/>
-        <source>&apos;%1&apos; theme already exists.  Please choose another name.</source>
+        <source>&apos;%1&apos; theme already exists. Please choose another name.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="390"/>
-        <source>Failed to rename theme.  Please check file permissions.</source>
+        <source>Failed to rename theme. Please check file permissions.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="435"/>
-        <source>Theme is read-only.  Please try renaming the theme, or setting the theme file to be writable.</source>
+        <source>Theme is read-only. Please try renaming the theme, or setting the theme file to be writable.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="472"/>
-        <source>Failed to remove old theme image.  Please check file permissions.</source>
+        <source>Failed to remove old theme image. Please check file permissions.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="504"/>
-        <source>The old theme image file could not be removed from the theme directory.  Please check file permissions.</source>
+        <source>The old theme image file could not be removed from the theme directory. Please check file permissions.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="516"/>
-        <source>Theme image file could not be copied to the theme directory.  Please check file permissions.</source>
+        <source>Theme image file could not be copied to the theme directory. Please check file permissions.</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="535"/>
-        <source>Theme could not be saved to disk.  Please check file permissions or try renaming the theme.</source>
+        <source>Theme could not be saved to disk. Please check file permissions or try renaming the theme.</source>
         <translation></translation>
     </message>
     <message>
@@ -1230,7 +1230,7 @@
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="659"/>
-        <source>Value for %1 is out of range.  Valid values are between %2 and %3, inclusive.</source>
+        <source>Value for %1 is out of range. Valid values are between %2 and %3, inclusive.</source>
         <translation></translation>
     </message>
 </context>

--- a/translations/ghostwriter_it.ts
+++ b/translations/ghostwriter_it.ts
@@ -411,7 +411,7 @@ NOTA: Il testo deve essere breve dato che spesso l&apos;utente lavorerà con la 
     </message>
     <message>
         <location filename="../src/HtmlPreview.cpp" line="123"/>
-        <source>No markdown (pandoc, multimarkdown, discount) processors are installed.  Please install or add their installation locations to your system PATH environment variable.</source>
+        <source>No markdown (pandoc, multimarkdown, discount) processors are installed. Please install or add their installation locations to your system PATH environment variable.</source>
         <translatorcomment>NOTA: La traduzione è molto lunga, bisogna verificare che non ecceda lo spazio di visualizzazion!</translatorcomment>
         <translation>Su questo PC non risulta presente alcuno strumento per l&apos;elaborazione del markdown (pandoc, , multimarkdown, discount). Sei pregato di installarne almeno uno, o di aggiungere alla variabile PATH del sistema il percorso di eventuali strumenti presenti nel sistema.</translation>
     </message>
@@ -1241,53 +1241,53 @@ NOTA: La consuetudine in Windows è di usare il plurale nei filtri, quindi l&apo
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="252"/>
-        <source>The specified theme is not available.  Try restarting the application.  If problem persists, please file a bug report.</source>
-        <translation>Il tema indicato non è disponibile.  Prova a riavvare l&apos;applicazione.  Se il problema persiste, segnalaci questo baco.</translation>
+        <source>The specified theme is not available. Try restarting the application. If problem persists, please file a bug report.</source>
+        <translation>Il tema indicato non è disponibile. Prova a riavvare l&apos;applicazione. Se il problema persiste, segnalaci questo baco.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="322"/>
-        <source>Could not delete %1 from theme.  Please try setting the theme file permissions to be writeable.</source>
-        <translation>Impossibile cancellare %1 dal tema.  Prova a modificare i permessi di scrittura del file del tema.</translation>
+        <source>Could not delete %1 from theme. Please try setting the theme file permissions to be writeable.</source>
+        <translation>Impossibile cancellare %1 dal tema. Prova a modificare i permessi di scrittura del file del tema.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="345"/>
-        <source>&apos;%1&apos; already exists.  Please choose another name.</source>
-        <translation>&apos;%1&apos; esiste già.  Scegli un altro nome.</translation>
+        <source>&apos;%1&apos; already exists. Please choose another name.</source>
+        <translation>&apos;%1&apos; esiste già. Scegli un altro nome.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="355"/>
-        <source>&apos;%1&apos; theme already exists.  Please choose another name.</source>
-        <translation>Il tema &apos;%1&apos; esiste già.  Scegli un altro nome.</translation>
+        <source>&apos;%1&apos; theme already exists. Please choose another name.</source>
+        <translation>Il tema &apos;%1&apos; esiste già. Scegli un altro nome.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="390"/>
-        <source>Failed to rename theme.  Please check file permissions.</source>
-        <translation>Non è stato possibile rinominare il tema.  Verifica i permessi del file.</translation>
+        <source>Failed to rename theme. Please check file permissions.</source>
+        <translation>Non è stato possibile rinominare il tema. Verifica i permessi del file.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="435"/>
-        <source>Theme is read-only.  Please try renaming the theme, or setting the theme file to be writable.</source>
-        <translation>Il tema è in sola lettura.  Prova a rinominare il tema, o a settare i permessi di scrittura del file del tema.</translation>
+        <source>Theme is read-only. Please try renaming the theme, or setting the theme file to be writable.</source>
+        <translation>Il tema è in sola lettura. Prova a rinominare il tema, o a settare i permessi di scrittura del file del tema.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="472"/>
-        <source>Failed to remove old theme image.  Please check file permissions.</source>
+        <source>Failed to remove old theme image. Please check file permissions.</source>
         <translation>Non è stato possibile eliminare la vecchia immagine del tema. Controlla i permessi del file.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="504"/>
-        <source>The old theme image file could not be removed from the theme directory.  Please check file permissions.</source>
-        <translation>Non è stato possibile cancellare il file dell&apos;immagine vecchia del tema dalla directory dei temi.  Verifica i permessi del file.</translation>
+        <source>The old theme image file could not be removed from the theme directory. Please check file permissions.</source>
+        <translation>Non è stato possibile cancellare il file dell&apos;immagine vecchia del tema dalla directory dei temi. Verifica i permessi del file.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="516"/>
-        <source>Theme image file could not be copied to the theme directory.  Please check file permissions.</source>
-        <translation>Non è stato possibile copiare il file dell&apos;immagine del tema nella directory dei temi.  Verifica i permessi dei file.</translation>
+        <source>Theme image file could not be copied to the theme directory. Please check file permissions.</source>
+        <translation>Non è stato possibile copiare il file dell&apos;immagine del tema nella directory dei temi. Verifica i permessi dei file.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="535"/>
-        <source>Theme could not be saved to disk.  Please check file permissions or try renaming the theme.</source>
-        <translation>Non è stato possibile salvare il tema su disco.  Verifica i permessi dei file, o prova a rinominare il tema.</translation>
+        <source>Theme could not be saved to disk. Please check file permissions or try renaming the theme.</source>
+        <translation>Non è stato possibile salvare il tema su disco. Verifica i permessi dei file, o prova a rinominare il tema.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="560"/>
@@ -1308,8 +1308,8 @@ NOTA: La consuetudine in Windows è di usare il plurale nei filtri, quindi l&apo
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="659"/>
-        <source>Value for %1 is out of range.  Valid values are between %2 and %3, inclusive.</source>
-        <translation>Il valore di %1 è fuori dal range.  I valori accettati vanno da %2 a %3 (inclusi).</translation>
+        <source>Value for %1 is out of range. Valid values are between %2 and %3, inclusive.</source>
+        <translation>Il valore di %1 è fuori dal range. I valori accettati vanno da %2 a %3 (inclusi).</translation>
     </message>
 </context>
 <context>

--- a/translations/ghostwriter_ja.ts
+++ b/translations/ghostwriter_ja.ts
@@ -383,7 +383,7 @@
     </message>
     <message>
         <location filename="../src/HtmlPreview.cpp" line="123"/>
-        <source>No markdown (pandoc, multimarkdown, discount) processors are installed.  Please install or add their installation locations to your system PATH environment variable.</source>
+        <source>No markdown (pandoc, multimarkdown, discount) processors are installed. Please install or add their installation locations to your system PATH environment variable.</source>
         <translation>markdown プロセッサ (pandoc, multimarkdown, discount) が見つかりません。インストールするかインストールした場所をシステム環境変数PATHに追加してください。</translation>
     </message>
     <message>
@@ -1161,53 +1161,53 @@
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="252"/>
-        <source>The specified theme is not available.  Try restarting the application.  If problem persists, please file a bug report.</source>
-        <translation>指定のテーマが見つかりません。  アプリを再起動してみてください。もしそれでも問題がある場合にはバグレポートを提出してください。</translation>
+        <source>The specified theme is not available. Try restarting the application. If problem persists, please file a bug report.</source>
+        <translation>指定のテーマが見つかりません。 アプリを再起動してみてください。もしそれでも問題がある場合にはバグレポートを提出してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="322"/>
-        <source>Could not delete %1 from theme.  Please try setting the theme file permissions to be writeable.</source>
-        <translation>テーマから  %1 を削除できません。  テーマ ファイルに書き込み権限を設定してください。</translation>
+        <source>Could not delete %1 from theme. Please try setting the theme file permissions to be writeable.</source>
+        <translation>テーマから  %1 を削除できません。 テーマ ファイルに書き込み権限を設定してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="345"/>
-        <source>&apos;%1&apos; already exists.  Please choose another name.</source>
-        <translation>&apos;%1&apos; はすでに存在します。  別の名前を選択してください。</translation>
+        <source>&apos;%1&apos; already exists. Please choose another name.</source>
+        <translation>&apos;%1&apos; はすでに存在します。 別の名前を選択してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="355"/>
-        <source>&apos;%1&apos; theme already exists.  Please choose another name.</source>
-        <translation>&apos;%1&apos; というテーマはすでに存在します。  別の名前を選択してください。</translation>
+        <source>&apos;%1&apos; theme already exists. Please choose another name.</source>
+        <translation>&apos;%1&apos; というテーマはすでに存在します。 別の名前を選択してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="390"/>
-        <source>Failed to rename theme.  Please check file permissions.</source>
+        <source>Failed to rename theme. Please check file permissions.</source>
         <translation>テーマ名の変更に失敗しました。ファイルの権限を確認してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="435"/>
-        <source>Theme is read-only.  Please try renaming the theme, or setting the theme file to be writable.</source>
-        <translation>テーマは読み取り専用です。  テーマ名を変更するかファイルを書き込み可能に設定してください。</translation>
+        <source>Theme is read-only. Please try renaming the theme, or setting the theme file to be writable.</source>
+        <translation>テーマは読み取り専用です。 テーマ名を変更するかファイルを書き込み可能に設定してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="472"/>
-        <source>Failed to remove old theme image.  Please check file permissions.</source>
-        <translation>古いテーマ画像の削除に失敗しました。  ファイルの権限を確認してください。</translation>
+        <source>Failed to remove old theme image. Please check file permissions.</source>
+        <translation>古いテーマ画像の削除に失敗しました。 ファイルの権限を確認してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="504"/>
-        <source>The old theme image file could not be removed from the theme directory.  Please check file permissions.</source>
-        <translation>古いテーマ画像をテーマ ディレクトリから削除できませんでした。  ファイルの権限を確認してください。</translation>
+        <source>The old theme image file could not be removed from the theme directory. Please check file permissions.</source>
+        <translation>古いテーマ画像をテーマ ディレクトリから削除できませんでした。 ファイルの権限を確認してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="516"/>
-        <source>Theme image file could not be copied to the theme directory.  Please check file permissions.</source>
-        <translation>テーマ画像ファイルをテーマ ディレクトリにコピーできませんでした。  ファイルの権限を確認してください。</translation>
+        <source>Theme image file could not be copied to the theme directory. Please check file permissions.</source>
+        <translation>テーマ画像ファイルをテーマ ディレクトリにコピーできませんでした。 ファイルの権限を確認してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="535"/>
-        <source>Theme could not be saved to disk.  Please check file permissions or try renaming the theme.</source>
-        <translation>テーマをディスクに保存できませんでした。  ファイルの権限を確認するかテーマ名を変更してください。</translation>
+        <source>Theme could not be saved to disk. Please check file permissions or try renaming the theme.</source>
+        <translation>テーマをディスクに保存できませんでした。 ファイルの権限を確認するかテーマ名を変更してください。</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="560"/>
@@ -1228,7 +1228,7 @@
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="659"/>
-        <source>Value for %1 is out of range.  Valid values are between %2 and %3, inclusive.</source>
+        <source>Value for %1 is out of range. Valid values are between %2 and %3, inclusive.</source>
         <translation>%1 は範囲外の値です。有効な値は %2 から %3 までの範囲です。</translation>
     </message>
 </context>

--- a/translations/ghostwriter_pt_BR.ts
+++ b/translations/ghostwriter_pt_BR.ts
@@ -384,7 +384,7 @@
     </message>
     <message>
         <location filename="../src/HtmlPreview.cpp" line="123"/>
-        <source>No markdown (pandoc, multimarkdown, discount) processors are installed.  Please install or add their installation locations to your system PATH environment variable.</source>
+        <source>No markdown (pandoc, multimarkdown, discount) processors are installed. Please install or add their installation locations to your system PATH environment variable.</source>
         <translation>Nenhum processador markdown (pandoc, multimarkdown, discount) está instalado. Por favor instale ou adicione suas localizações à variável de sistema PATH.</translation>
     </message>
     <message>
@@ -1163,53 +1163,53 @@
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="252"/>
-        <source>The specified theme is not available.  Try restarting the application.  If problem persists, please file a bug report.</source>
-        <translation>O tema especificado não está disponível:  Tente reiniciar a aplicação.  Se o problema persistir, favor registrar um bug.</translation>
+        <source>The specified theme is not available. Try restarting the application. If problem persists, please file a bug report.</source>
+        <translation>O tema especificado não está disponível:  Tente reiniciar a aplicação. Se o problema persistir, favor registrar um bug.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="322"/>
-        <source>Could not delete %1 from theme.  Please try setting the theme file permissions to be writeable.</source>
-        <translation>Impossível apagar %1 dos temas.  Por favor mude as permissões do tema para permitir escrita.</translation>
+        <source>Could not delete %1 from theme. Please try setting the theme file permissions to be writeable.</source>
+        <translation>Impossível apagar %1 dos temas. Por favor mude as permissões do tema para permitir escrita.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="345"/>
-        <source>&apos;%1&apos; already exists.  Please choose another name.</source>
-        <translation>&apos;%1&apos; já existe.  Favor escolher outro nome.</translation>
+        <source>&apos;%1&apos; already exists. Please choose another name.</source>
+        <translation>&apos;%1&apos; já existe. Favor escolher outro nome.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="355"/>
-        <source>&apos;%1&apos; theme already exists.  Please choose another name.</source>
+        <source>&apos;%1&apos; theme already exists. Please choose another name.</source>
         <translation>O tema &apos;%1&apos; já existe. Favor escolher outro nome.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="390"/>
-        <source>Failed to rename theme.  Please check file permissions.</source>
+        <source>Failed to rename theme. Please check file permissions.</source>
         <translation>Falha ao renomear tema. Favor verificar permissões dos arquivos.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="435"/>
-        <source>Theme is read-only.  Please try renaming the theme, or setting the theme file to be writable.</source>
-        <translation>O tema é de somente leitura.  Por favor tente renomear o tema ou alterar a permissão de escrita do arquivo do tema.</translation>
+        <source>Theme is read-only. Please try renaming the theme, or setting the theme file to be writable.</source>
+        <translation>O tema é de somente leitura. Por favor tente renomear o tema ou alterar a permissão de escrita do arquivo do tema.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="472"/>
-        <source>Failed to remove old theme image.  Please check file permissions.</source>
-        <translation>Falha ao remover imagem anterior do tema.  Favor verificar permissões de arquivos.</translation>
+        <source>Failed to remove old theme image. Please check file permissions.</source>
+        <translation>Falha ao remover imagem anterior do tema. Favor verificar permissões de arquivos.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="504"/>
-        <source>The old theme image file could not be removed from the theme directory.  Please check file permissions.</source>
-        <translation>A imagem anterior do tema não pôde ser removida do diretório de temas.  Favor verificar permissões de arquivos.</translation>
+        <source>The old theme image file could not be removed from the theme directory. Please check file permissions.</source>
+        <translation>A imagem anterior do tema não pôde ser removida do diretório de temas. Favor verificar permissões de arquivos.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="516"/>
-        <source>Theme image file could not be copied to the theme directory.  Please check file permissions.</source>
-        <translation>A imagem do tema não pôde ser copiada para o diretório de temas.  Favor verificar permissões de arquivos.</translation>
+        <source>Theme image file could not be copied to the theme directory. Please check file permissions.</source>
+        <translation>A imagem do tema não pôde ser copiada para o diretório de temas. Favor verificar permissões de arquivos.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="535"/>
-        <source>Theme could not be saved to disk.  Please check file permissions or try renaming the theme.</source>
-        <translation>O tema não pôde ser salvo no disco.  Por favor verifique as permissões de escrita ou tente renomear o tema.</translation>
+        <source>Theme could not be saved to disk. Please check file permissions or try renaming the theme.</source>
+        <translation>O tema não pôde ser salvo no disco. Por favor verifique as permissões de escrita ou tente renomear o tema.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="560"/>
@@ -1230,8 +1230,8 @@
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="659"/>
-        <source>Value for %1 is out of range.  Valid values are between %2 and %3, inclusive.</source>
-        <translation>O valor para %1 está fora dos limites.  Valores válidos são entre %2 e %3, inclusive.</translation>
+        <source>Value for %1 is out of range. Valid values are between %2 and %3, inclusive.</source>
+        <translation>O valor para %1 está fora dos limites. Valores válidos são entre %2 e %3, inclusive.</translation>
     </message>
 </context>
 <context>

--- a/translations/ghostwriter_ru.ts
+++ b/translations/ghostwriter_ru.ts
@@ -385,7 +385,7 @@
     </message>
     <message>
         <location filename="../src/HtmlPreview.cpp" line="123"/>
-        <source>No markdown (pandoc, multimarkdown, discount) processors are installed.  Please install or add their installation locations to your system PATH environment variable.</source>
+        <source>No markdown (pandoc, multimarkdown, discount) processors are installed. Please install or add their installation locations to your system PATH environment variable.</source>
         <translation>Не установлено ни одного обработчика markdown (pandoc, multimarkdown, discount). Пожалуйста, установите их или добавьте пути установки в переменную окружения PATH.</translation>
     </message>
     <message>
@@ -1168,52 +1168,52 @@
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="252"/>
-        <source>The specified theme is not available.  Try restarting the application.  If problem persists, please file a bug report.</source>
+        <source>The specified theme is not available. Try restarting the application. If problem persists, please file a bug report.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="322"/>
-        <source>Could not delete %1 from theme.  Please try setting the theme file permissions to be writeable.</source>
+        <source>Could not delete %1 from theme. Please try setting the theme file permissions to be writeable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="345"/>
-        <source>&apos;%1&apos; already exists.  Please choose another name.</source>
+        <source>&apos;%1&apos; already exists. Please choose another name.</source>
         <translation>«%1» уже существует. Пожалуйста, выберите другое имя.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="355"/>
-        <source>&apos;%1&apos; theme already exists.  Please choose another name.</source>
+        <source>&apos;%1&apos; theme already exists. Please choose another name.</source>
         <translation>Тема «%1»уже существует. Пожалуйста, выберите другое имя.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="390"/>
-        <source>Failed to rename theme.  Please check file permissions.</source>
+        <source>Failed to rename theme. Please check file permissions.</source>
         <translation>Не удалось переменовать тему. Пожалуйста, проверьте права на файл.</translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="435"/>
-        <source>Theme is read-only.  Please try renaming the theme, or setting the theme file to be writable.</source>
+        <source>Theme is read-only. Please try renaming the theme, or setting the theme file to be writable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="472"/>
-        <source>Failed to remove old theme image.  Please check file permissions.</source>
+        <source>Failed to remove old theme image. Please check file permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="504"/>
-        <source>The old theme image file could not be removed from the theme directory.  Please check file permissions.</source>
+        <source>The old theme image file could not be removed from the theme directory. Please check file permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="516"/>
-        <source>Theme image file could not be copied to the theme directory.  Please check file permissions.</source>
+        <source>Theme image file could not be copied to the theme directory. Please check file permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="535"/>
-        <source>Theme could not be saved to disk.  Please check file permissions or try renaming the theme.</source>
+        <source>Theme could not be saved to disk. Please check file permissions or try renaming the theme.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1235,7 +1235,7 @@
     </message>
     <message>
         <location filename="../src/ThemeFactory.cpp" line="659"/>
-        <source>Value for %1 is out of range.  Valid values are between %2 and %3, inclusive.</source>
+        <source>Value for %1 is out of range. Valid values are between %2 and %3, inclusive.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
* address #56
* adds German UI strings, but still misses *Quick Reference Guide* in German.
* fixes whitespace in all other translations
* updated `CREDITS.md`

---

/cc @wereturtle Should you merge this before I add the German Quick Reference Guide, I'll open a new PR for [1.5.0](https://github.com/wereturtle/ghostwriter/milestones/v1.5.0).