### PR TITLE
initial snapcraft.yaml to build a .snap package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,11 @@ Makefile*
 *.qm
 
 build/
+
+# snap
+ghostwriter_*.snap
+
+# snap build directories
+parts/
+prime/
+stage/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,43 @@
+name: ghostwriter
+version: 1.4.2
+summary: ghostwriter is a cross-platform, aesthetic, distraction-free Markdown editor
+description: |
+  ghostwriter is a Windows and Linux text editor for Markdown,
+  which is a plain text markup format created by John Gruber.
+  For more information about Markdown, please visit John Gruber’s
+  website at http://www.daringfireball.net. ghostwriter provides
+  a relaxing, distraction-free writing environment, whether your
+  masterpiece be that next blog post, your school paper, or your
+  NaNoWriMo novel.
+
+confinement: strict # devmode
+grade: devel        # must be 'stable' to release into candidate/stable channels
+
+apps:
+  ghostwriter:
+    command: desktop-launch $SNAP/usr/local/bin/ghostwriter
+    plugs: [home, x11, opengl, unity7] # network?
+
+parts:
+  ghostwriter:
+    plugin: qmake
+    qt-version: qt5
+    source: https://github.com/wereturtle/ghostwriter.git
+    project-files:
+      - ghostwriter.pro
+    stage-packages:
+      - build-essential
+      - libhunspell-dev
+      - pkg-config
+      - qtbase5-dev
+      - qtmultimedia5-dev
+      - libqt5concurrent5
+      - libqt5printsupport5
+      - libqt5svg5
+      - qt5-default
+      - libqt5svg5-dev
+      - libqt5webkit5-dev
+    after: [desktop-qt5]
+    snap:
+      # delete files & folders by prefixing them with a -
+      - -usr/share/doc


### PR DESCRIPTION
Added a file to build a ghostwriter [snap package](http://snapcraft.io/docs/).

Tested on: Ubuntu 17.04 dev 64-Bit

The snapcraft.yaml works, but needs more love (not needed files/libs should be removed from the resulting snap). This commit is just to get you started. If you want you could publish the ghostwriter snap to the Ubuntu Store [edge-channel](http://snapcraft.io/docs/build-snaps/publish), to make a snappy-start and see how things go :)

How to build, install and publish a snap:

* Install Snapcraft: `sudo apt install snapcraft`
* Move to the ghostwriter source directory
* Build the snap with: `snapcraft`
* Install the snap locally with: `sudo snap install --force-dangerous ghostwriter_1.4.2_amd64.snap`
* Publish the snap to the [Ubuntu Store](myapps.developer.ubuntu.com)

PS: My motivation was that I read about ghostwriter at OMG Ubuntu and thought, not again an app that needs a PPA! So I build with my moderate snappy knowledge an initial snapcraft.yaml for ghostwriter.