### PR TITLE
A proposition to enable regexp replacement to work as regexp replacement in IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Makefile*
 *.qm
 
 build/
+.kdev4/
+ghostwriter.kdev4

--- a/src/CommandLineExporter.cpp
+++ b/src/CommandLineExporter.cpp
@@ -21,6 +21,7 @@
 #include <QFileInfo>
 #include <QObject>
 #include <QDir>
+#include <QUrl>
 
 #include "CommandLineExporter.h"
 
@@ -33,14 +34,10 @@ CommandLineExporter::CommandLineExporter(const QString& name)
     : Exporter(name), smartTypographyOnArgument(""),
         smartTypographyOffArgument(""),
         htmlRenderCommand(QString())
-{
-    ;
-}
+{}
 
 CommandLineExporter::~CommandLineExporter()
-{
-    ;
-}
+{}
 
 void CommandLineExporter::setHtmlRenderCommand(const QString& command)
 {
@@ -87,7 +84,7 @@ void CommandLineExporter::exportToHtml(const QString& text, QString& html)
         return;
     }
 
-    if (!executeCommand(htmlRenderCommand, QString(), text, QString(), html, stderrOuptut))
+    if (!executeCommand(htmlRenderCommand, QUrl(),  QString(), text, QString(), html, stderrOuptut))
     {
         html = QString("<center><b style='color: red'>") + QObject::tr("Export failed: ") + QString("%1</b></center>)").arg(htmlRenderCommand);
     }
@@ -100,6 +97,7 @@ void CommandLineExporter::exportToHtml(const QString& text, QString& html)
 void CommandLineExporter::exportToFile
 (
     const ExportFormat* format,
+    const QUrl& stylesheet,
     const QString& inputFilePath,
     const QString& text,
     const QString& outputFilePath,
@@ -117,7 +115,7 @@ void CommandLineExporter::exportToFile
 
     QString command = formatToCommandMap.value(format);
 
-    if (!executeCommand(command, inputFilePath, text, outputFilePath, stdoutOutput, stderrOuptut))
+    if (!executeCommand(command, stylesheet, inputFilePath, text, outputFilePath, stdoutOutput, stderrOuptut))
     {
         err = QObject::tr("Failed to execute command: ") + QString("%1").arg(command);
     }
@@ -134,6 +132,7 @@ void CommandLineExporter::exportToFile
 bool CommandLineExporter::executeCommand
 (
     const QString& command,
+    const QUrl& stylesheet,
     const QString& inputFilePath,
     const QString& textInput,
     const QString& outputFilePath,
@@ -143,8 +142,17 @@ bool CommandLineExporter::executeCommand
 {
     QProcess process;
     process.setReadChannel(QProcess::StandardOutput);
+    QString commandSuffix;
+    
+    if (stylesheet.toLocalFile() != NULL) {
+      commandSuffix = QString(" --css ") + stylesheet.toLocalFile();
+    } else {
+      commandSuffix = QString(" ");
+    }
 
-    QString expandedCommand = command + QString(" ");
+    QString expandedCommand = command + commandSuffix;
+    
+    
 
     if (!outputFilePath.isNull() && !outputFilePath.isEmpty())
     {

--- a/src/CommandLineExporter.h
+++ b/src/CommandLineExporter.h
@@ -100,6 +100,7 @@ class CommandLineExporter : public Exporter
         void exportToFile
         (
             const ExportFormat* format,
+	    const QUrl& stylesheet,
             const QString& inputFilePath,
             const QString& text,
             const QString& outputFilePath,
@@ -172,6 +173,7 @@ class CommandLineExporter : public Exporter
         bool executeCommand
         (
             const QString& command,
+	    const QUrl& stylesheet,
             const QString& inputFilePath,
             const QString& textInput,
             const QString& outputFilePath,

--- a/src/ExportDialog.cpp
+++ b/src/ExportDialog.cpp
@@ -241,6 +241,7 @@ void ExportDialog::accept()
                 exporter->exportToFile
                 (
                     format,
+		    this->stylesheet,
                     this->document->getFilePath(),
                     document->toPlainText(),
                     fileName,
@@ -308,3 +309,9 @@ void ExportDialog::onFilterSelected(const QString& filter)
         }
     }
 }
+
+void ExportDialog::setStyle(const QUrl& stylesheet)
+{
+  this->stylesheet = stylesheet;
+}
+

--- a/src/ExportDialog.h
+++ b/src/ExportDialog.h
@@ -21,6 +21,7 @@
 #define EXPORTDIALOG_H
 
 #include <QDialog>
+#include <QUrl>
 
 #include "TextDocument.h"
 
@@ -44,8 +45,9 @@ class ExportDialog : public QDialog
          * Constructor that takes text document to export as the parameter,
          * as well as the parent widget which will own this dialog.
          */
-        ExportDialog(TextDocument* document, QWidget* parent = 0);
+        ExportDialog(TextDocument* document, QWidget* parent = 0);	
         virtual ~ExportDialog();
+        void setStyle(const QUrl& stylesheet);
 
     signals:
         /**
@@ -92,6 +94,7 @@ class ExportDialog : public QDialog
         QCheckBox* smartTypographyCheckBox;
         TextDocument* document;
         QStringList fileFilters;
+	QUrl stylesheet;
 };
 
 #endif // EXPORTDIALOG_H

--- a/src/Exporter.h
+++ b/src/Exporter.h
@@ -98,6 +98,7 @@ class Exporter
         virtual void exportToFile
         (
             const ExportFormat* format,
+	    const QUrl& stylesheet,
             const QString& inputFilePath,
             const QString& text,
             const QString& outputFilePath,

--- a/src/ExporterFactory.cpp
+++ b/src/ExporterFactory.cpp
@@ -252,21 +252,21 @@ void ExporterFactory::addPandocExporter
 {
     CommandLineExporter* exporter = new CommandLineExporter(name);
     exporter->setSmartTypographyOnArgument("--smart");
-    exporter->setHtmlRenderCommand(QString("pandoc %1 -f %2 -t html")
+    exporter->setHtmlRenderCommand(QString("pandoc %1 -f %2 -t html5")
         .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
         .arg(inputFormat));
     exporter->addFileExportCommand
     (
-        ExportFormat::HTML,
-        QString("pandoc %1 -f %2 -t html --standalone -o %3")
+        ExportFormat::HTML5,
+        QString("pandoc %1 -f %2 -t html5 --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
     );
     exporter->addFileExportCommand
     (
-        ExportFormat::HTML5,
-        QString("pandoc %1 -f %2 -t html5 --standalone -o %3")
+        ExportFormat::HTML,
+        QString("pandoc %1 -f %2 -t html --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -274,7 +274,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::ODT,
-        QString("pandoc %1 -f %2 -t odt --standalone -o %3")
+        QString("pandoc %1 -f %2 -t odt --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -282,7 +282,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::ODF,
-        QString("pandoc %1 -f %2 -t opendocument --standalone -o %3")
+        QString("pandoc %1 -f %2 -t opendocument --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -290,7 +290,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::RTF,
-        QString("pandoc %1 -f %2 -t rtf --standalone -o %3")
+        QString("pandoc %1 -f %2 -t rtf --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -298,7 +298,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::DOCX,
-        QString("pandoc %1 -f %2 -t docx --standalone -o %3")
+        QString("pandoc %1 -f %2 -t docx --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -306,7 +306,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::PDF_LATEX,
-        QString("pandoc %1 -f %2 -t latex -Vlinkcolor=blue -Vcitecolor=blue -Vurlcolor=blue -Vtoccolor=blue -Vmargin-left=1in -Vmargin-right=1in -Vmargin-top=1in -Vmargin-bottom=1in --standalone -o %3")
+        QString("pandoc %1 -f %2 -t latex -Vlinkcolor=blue -Vcitecolor=blue -Vurlcolor=blue -Vtoccolor=blue -Vmargin-left=1in -Vmargin-right=1in -Vmargin-top=1in -Vmargin-bottom=1in --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -314,7 +314,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::PDF_CONTEXT,
-        QString("pandoc %1 -f %2 -t context --variable pagenumbering:location=footer --variable layout:header=0mm --variable layout:top=1in --variable layout:bottom=1in --variable layout:leftmargin=1in --variable layout:rightmargin=1in -Vlinkcolor=blue --standalone -o %3")
+        QString("pandoc %1 -f %2 -t context --variable pagenumbering:location=footer --variable layout:header=0mm --variable layout:top=1in --variable layout:bottom=1in --variable layout:leftmargin=1in --variable layout:rightmargin=1in -Vlinkcolor=blue --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -322,7 +322,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::PDF_WKHTML,
-        QString("pandoc %1 -f %2 -t html5 -Vmargin-left=1in -Vmargin-right=1in -Vmargin-top=1in -Vmargin-bottom=1in --mathjax --standalone -o %3")
+        QString("pandoc %1 -f %2 -t html5 -Vmargin-left=1in -Vmargin-right=1in -Vmargin-top=1in -Vmargin-bottom=1in --mathjax --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -330,7 +330,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::EPUBV2,
-        QString("pandoc %1 -f %2 -t epub --standalone --toc --toc-depth 6 -o %3")
+        QString("pandoc %1 -f %2 -t epub --self-contained --toc --toc-depth 6 -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -338,7 +338,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::EPUBV3,
-        QString("pandoc %1 -f %2 -t epub3 --standalone --toc --toc-depth 6 -o %3")
+        QString("pandoc %1 -f %2 -t epub3 --self-contained --toc --toc-depth 6 -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -346,7 +346,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::FICTIONBOOK2,
-        QString("pandoc %1 -f %2 -t fb2 --standalone --toc --toc-depth 6 -o %3")
+        QString("pandoc %1 -f %2 -t fb2 --self-contained --toc --toc-depth 6 -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -354,7 +354,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::LATEX,
-        QString("pandoc %1 -f %2 -t latex --standalone -o %3")
+        QString("pandoc %1 -f %2 -t latex --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)
@@ -362,7 +362,7 @@ void ExporterFactory::addPandocExporter
     exporter->addFileExportCommand
     (
         ExportFormat::GROFFMAN,
-        QString("pandoc %1 -f %2 -t man --standalone -o %3")
+        QString("pandoc %1 -f %2 -t man --self-contained -o %3")
             .arg(CommandLineExporter::SMART_TYPOGRAPHY_ARG)
             .arg(inputFormat)
             .arg(CommandLineExporter::OUTPUT_FILE_PATH_VAR)

--- a/src/HtmlPreview.cpp
+++ b/src/HtmlPreview.cpp
@@ -535,6 +535,7 @@ void HtmlPreview::printHtmlToPrinter(QPrinter* printer)
 void HtmlPreview::onExport()
 {
     ExportDialog exportDialog(document);
+    exportDialog.setStyle(htmlBrowser->settings()->userStyleSheetUrl());
 
     connect(&exportDialog, SIGNAL(exportStarted(QString)), this, SIGNAL(operationStarted(QString)));
     connect(&exportDialog, SIGNAL(exportComplete()), this, SIGNAL(operationFinished()));

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1324,7 +1324,7 @@ void MainWindow::buildMenuBar()
     editMenu->addAction(tr("&Insert Image..."), this, SLOT(insertImage()));
     editMenu->addSeparator();
     editMenu->addAction(tr("&Find"), findReplaceDialog, SLOT(showFindMode()), QKeySequence::Find);
-    editMenu->addAction(tr("Rep&lace"), findReplaceDialog, SLOT(showReplaceMode()), QKeySequence::Replace);
+    editMenu->addAction(tr("Rep&lace"), findReplaceDialog, SLOT(showReplaceMode()), QKeySequence("Ctrl+R"));
     editMenu->addSeparator();
     editMenu->addAction(tr("&Spell check"), editor, SLOT(runSpellChecker()));
 

--- a/src/StyleSheetManagerDialog.h
+++ b/src/StyleSheetManagerDialog.h
@@ -46,7 +46,7 @@ class StyleSheetManagerDialog : public QDialog
         /**
          * Destructor.
          */
-        ~StyleSheetManagerDialog();
+        virtual ~StyleSheetManagerDialog();
 
         /**
          * Gets the list of user style sheets (as file paths).  Call this

--- a/src/SundownExporter.cpp
+++ b/src/SundownExporter.cpp
@@ -25,6 +25,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QTextStream>
+#include <QUrl>
 
 #include "SundownExporter.h"
 
@@ -112,6 +113,7 @@ void SundownExporter::exportToHtml(const QString& text, QString& html)
 void SundownExporter::exportToFile
 (
     const ExportFormat* format,
+    const QUrl& stylesheet,
     const QString& inputFilePath,
     const QString& text,
     const QString& outputFilePath,

--- a/src/SundownExporter.h
+++ b/src/SundownExporter.h
@@ -36,7 +36,7 @@ class SundownExporter : public Exporter
         /**
          * Destructor.
          */
-        ~SundownExporter();
+        virtual ~SundownExporter();
 
         /**
          * Exports the given Markdown text to HTML, setting the html parameter
@@ -53,6 +53,7 @@ class SundownExporter : public Exporter
         void exportToFile
         (
             const ExportFormat* format,
+	    const QUrl& stylesheet,
             const QString& inputFilePath,
             const QString& text,
             const QString& outputFilePath,

--- a/src/Theme.h
+++ b/src/Theme.h
@@ -66,7 +66,7 @@ class Theme
     public:
         Theme();
         Theme(const QString& name, bool builtIn = true);
-        ~Theme();
+        virtual ~Theme();
 
         QString getName() const;
         void setName(const QString& value);

--- a/src/find_dialog.cpp
+++ b/src/find_dialog.cpp
@@ -205,8 +205,8 @@ void FindDialog::findChanged(const QString& text)
 
 void FindDialog::replace()
 {
-	QString text = m_find_string->text();
-	if (text.isEmpty()) {
+	QString searchText = m_find_string->text();
+	if (searchText.isEmpty()) {
 		return;
 	}
 
@@ -214,20 +214,34 @@ void FindDialog::replace()
 	QTextCursor cursor = document->textCursor();
 	Qt::CaseSensitivity cs = m_ignore_case->isChecked() ? Qt::CaseInsensitive : Qt::CaseSensitive;
 	if (!m_regular_expressions->isChecked()) {
-		if (QString::compare(cursor.selectedText(), text, cs) == 0) {
+		if (QString::compare(cursor.selectedText(), searchText, cs) == 0) {
 			cursor.insertText(m_replace_string->text());
 			document->setTextCursor(cursor);
 		}
 	} else {
-		QRegExp regex(text, cs, QRegExp::RegExp2);
-		QString match = cursor.selectedText();
-        if (regex.exactMatch(match)) {
-            match.replace(regex, m_replace_string->text());
-			cursor.insertText(match);
-			document->setTextCursor(cursor);
-		}
-	}
+		QRegExp regex(searchText, cs, QRegExp::RegExp2);
+        	QString match = cursor.selectedText();
 
+        	if (regex.indexIn(match) != -1) {
+	    		QString* replacement = NULL;	    
+            		QStringList groupsList = regex.capturedTexts();
+            		if (groupsList.length() > 1) {
+                		for (int g = 1; g < groupsList.length(); g++) {
+		  		if (replacement == NULL) {
+		   			replacement =  new QString(m_replace_string->text());
+		  		} 
+                  		replacement->replace(QStringLiteral("$%1").arg(g), groupsList.at(g), cs);
+                	}
+            	}
+            	match.replace(regex, *replacement);
+            	cursor.insertText(match);
+            	document->setTextCursor(cursor);
+        	} else if (regex.exactMatch(match)) {
+            		match.replace(regex, m_replace_string->text());
+            		cursor.insertText(match);
+            		document->setTextCursor(cursor);
+        	}
+	}
 	find();
 }
 
@@ -286,7 +300,7 @@ void FindDialog::replaceAll()
 	QTextCursor start_cursor = document->textCursor();
     start_cursor.beginEditBlock();
 	if (!m_regular_expressions->isChecked()) {
-        forever {
+	  forever {
 			cursor = document->document()->find(text, cursor, flags);
             if (!cursor.isNull()) {
                 cursor.insertText(m_replace_string->text());
@@ -295,16 +309,29 @@ void FindDialog::replaceAll()
 			}
 		}
 	} else {
-        forever {
-			cursor = document->document()->find(regex, cursor, flags);
-			if (!cursor.isNull() && cursor.hasSelection()) {
-                QString match = cursor.selectedText();
-                match.replace(regex, m_replace_string->text());
-                cursor.insertText(match);
-			} else {
-				break;
-			}
-		}
+	  forever {
+		cursor = document->document()->find(regex, cursor, flags);
+            	if (!cursor.isNull() && cursor.hasSelection()) {
+	      		Qt::CaseSensitivity cs = m_ignore_case->isChecked() ? Qt::CaseInsensitive : Qt::CaseSensitive;
+	      		QString match = cursor.selectedText();
+	      		if (regex.indexIn(match) != -1) {
+				QString* replacement = NULL; 
+				QStringList groupsList = regex.capturedTexts();
+				if (groupsList.length() > 1) {
+			    		for (int g = 1; g < groupsList.length(); g++) {
+		      				if (replacement == NULL) {
+		      					replacement =  new QString(m_replace_string->text());
+		      				} 
+		      				replacement->replace(QStringLiteral("$%1").arg(g), groupsList.at(g), cs);
+		    			}
+				}
+				match.replace(regex, *replacement);
+                		cursor.insertText(match);
+	      		}
+            	} else {
+                	break;
+            	}
+	  }
 	}
     start_cursor.endEditBlock();
     document->setTextCursor(start_cursor);

--- a/src/find_dialog.cpp
+++ b/src/find_dialog.cpp
@@ -227,16 +227,18 @@ void FindDialog::replace()
             		QStringList groupsList = regex.capturedTexts();
             		if (groupsList.length() > 1) {
                 		for (int g = 1; g < groupsList.length(); g++) {
-		  		if (replacement == NULL) {
+				  if (replacement == NULL) {
 		   			replacement =  new QString(m_replace_string->text());
-		  		} 
-                  		replacement->replace(QStringLiteral("$%1").arg(g), groupsList.at(g), cs);
-                	}
-            	}
-            	match.replace(regex, *replacement);
-		delete replacement;
-            	cursor.insertText(match);
-            	document->setTextCursor(cursor);
+				  } 
+				  replacement->replace(QStringLiteral("$%1").arg(g), groupsList.at(g), cs);
+				}
+			      match.replace(regex, *replacement);
+			      delete replacement;
+			} else {
+			  match.replace(regex, m_replace_string->text());  
+			}
+			cursor.insertText(match);
+			document->setTextCursor(cursor);
         	} else if (regex.exactMatch(match)) {
             		match.replace(regex, m_replace_string->text());
             		cursor.insertText(match);
@@ -325,11 +327,14 @@ void FindDialog::replaceAll()
 		      				} 
 		      				replacement->replace(QStringLiteral("$%1").arg(g), groupsList.at(g), cs);
 		    			}
+		    			match.replace(regex, *replacement);
+					delete replacement;
+				} else {
+					match.replace(regex, m_replace_string->text());  
 				}
-				match.replace(regex, *replacement);
-				delete replacement;
-                		cursor.insertText(match);
-	      		}
+				cursor.insertText(match);
+				document->setTextCursor(cursor);		
+			}
             	} else {
                 	break;
             	}

--- a/src/find_dialog.cpp
+++ b/src/find_dialog.cpp
@@ -234,6 +234,7 @@ void FindDialog::replace()
                 	}
             	}
             	match.replace(regex, *replacement);
+		delete replacement;
             	cursor.insertText(match);
             	document->setTextCursor(cursor);
         	} else if (regex.exactMatch(match)) {
@@ -326,6 +327,7 @@ void FindDialog::replaceAll()
 		    			}
 				}
 				match.replace(regex, *replacement);
+				delete replacement;
                 		cursor.insertText(match);
 	      		}
             	} else {


### PR DESCRIPTION
Hi,

I have this proposition if interested in it.

The proposed code adds regexp group matches replacement. 
For instance, with a search string like '([0-9]*)(B)' and a replacemente string like '$1:$2', a string like '4B' would be replaced by '4:B'

Thanks for your tool and thanks for having made it open sourced ;-)
Best regards
Tony

