### PR TITLE
hunspell: look for mozilla-dicts

### DIFF
--- a/src/spelling/dictionary_provider_hunspell.cpp
+++ b/src/spelling/dictionary_provider_hunspell.cpp
@@ -301,7 +301,7 @@ DictionaryProviderHunspell::DictionaryProviderHunspell()
 		xdg.append("/usr/local/share");
 		xdg.append("/usr/share");
 	}
-	QStringList subdirs = QStringList() << "/hunspell" << "/myspell/dicts" << "/myspell";
+	QStringList subdirs = QStringList() << "/hunspell" << "/myspell/dicts" << "/myspell" << "/mozilla-dicts";
 	foreach (const QString& subdir, subdirs) {
 		foreach (const QString& dir, xdg) {
 			QString path = dir + subdir;


### PR DESCRIPTION
On OpenBSD hunspell dictionaries are not packaged, instead users are expected
to install `mozilla-dicts` packages (like `mozilla-dicts-pl`) which results in hunspell
compatible dictionaries being installed under `/usr/local/share/mozilla-dicts`

example of dicts installed by `mozilla-dicts-pl`:
`/usr/local/share/mozilla-dicts/pl.aff`
`/usr/local/share/mozilla-dicts/pl.dic`

This change makes the hunspell dictionary provider look for the mozilla-dicts
sub-directory, effectively enabling spellchecking on OpenBSD.

tested on OpenBSD/amd64 -current