### PR TITLE
Add optional typing sounds

### DIFF
--- a/ghostwriter.pro
+++ b/ghostwriter.pro
@@ -28,7 +28,7 @@ isEqual(QT_MAJOR_VERSION, 5) : lessThan(QT_MINOR_VERSION, 2) {
 
 TEMPLATE = app
 
-QT += printsupport webkitwidgets widgets concurrent
+QT += printsupport webkitwidgets widgets concurrent multimedia
 
 CONFIG -= debug
 CONFIG += warn_on

--- a/src/AppSettings.cpp
+++ b/src/AppSettings.cpp
@@ -39,6 +39,7 @@
 #define GW_HIGHLIGHT_LINE_BREAKS "Style/highlightLineBreaks"
 #define GW_AUTO_MATCH_KEY "Typing/autoMatchEnabled"
 #define GW_AUTO_MATCH_FILTER_KEY "Typing/autoMatchFilter"
+#define GW_TYPING_SOUNDS_KEY "Sounds/typingSoundsEnabled"
 #define GW_BULLET_CYCLING_KEY "Typing/bulletPointCyclingEnabled"
 #define GW_UNDERLINE_ITALICS_KEY "Style/underlineInsteadOfItalics"
 #define GW_FOCUS_MODE_KEY "Style/focusMode"
@@ -93,6 +94,7 @@ void AppSettings::store()
     appSettings.setValue(GW_HIGHLIGHT_LINE_BREAKS, QVariant(highlightLineBreaks));
     appSettings.setValue(GW_AUTO_MATCH_KEY, QVariant(autoMatchEnabled));
     appSettings.setValue(GW_AUTO_MATCH_FILTER_KEY, QVariant(autoMatchedCharFilter));
+    appSettings.setValue(GW_TYPING_SOUNDS_KEY, QVariant(typingSoundsEnabled));
     appSettings.setValue(GW_BULLET_CYCLING_KEY, QVariant(bulletPointCyclingEnabled));
 
     appSettings.setValue(GW_UNDERLINE_ITALICS_KEY, QVariant(useUnderlineForEmphasis));
@@ -265,6 +267,17 @@ void AppSettings::setAutoMatchCharEnabled(const QChar openingCharacter, bool ena
         default:
             break;
     }
+}
+
+bool AppSettings::getTypingSoundsEnabled() const
+{
+    return typingSoundsEnabled;
+}
+
+void AppSettings::setTypingSoundsEnabled(bool enabled)
+{
+    typingSoundsEnabled = enabled;
+    emit typingSoundsChanged(enabled);
 }
 
 bool AppSettings::getBulletPointCyclingEnabled() const
@@ -722,6 +735,7 @@ AppSettings::AppSettings()
     highlightLineBreaks = appSettings.value(GW_HIGHLIGHT_LINE_BREAKS, QVariant(false)).toBool();
     autoMatchEnabled = appSettings.value(GW_AUTO_MATCH_KEY, QVariant(true)).toBool();
     autoMatchedCharFilter = appSettings.value(GW_AUTO_MATCH_FILTER_KEY, QVariant("\"\'([{*_`<")).toString();
+    typingSoundsEnabled = appSettings.value(GW_TYPING_SOUNDS_KEY, QVariant(false)).toBool();
     bulletPointCyclingEnabled = appSettings.value(GW_BULLET_CYCLING_KEY, QVariant(true)).toBool();
     focusMode = (FocusMode) appSettings.value(GW_FOCUS_MODE_KEY, QVariant(FocusModeSentence)).toInt();
 

--- a/src/AppSettings.h
+++ b/src/AppSettings.h
@@ -89,6 +89,10 @@ class AppSettings : public QObject
         Q_SLOT void setAutoMatchCharEnabled(const QChar openingCharacter, bool enabled);
         Q_SIGNAL void autoMatchCharChanged(const QChar openingChar, bool enabled);
 
+        bool getTypingSoundsEnabled() const;
+        Q_SLOT void setTypingSoundsEnabled(bool enabled);
+        Q_SIGNAL void typingSoundsChanged(bool enabled);
+
         bool getBulletPointCyclingEnabled() const;
         Q_SLOT void setBulletPointCyclingEnabled(bool enabled);
         Q_SIGNAL void bulletPointCyclingChanged(bool enabled);
@@ -195,6 +199,7 @@ class AppSettings : public QObject
         bool useUnderlineForEmphasis;
         bool largeHeadingSizesEnabled;
         bool autoMatchEnabled;
+        bool typingSoundsEnabled;
         QString autoMatchedCharFilter;
         bool bulletPointCyclingEnabled;
         FocusMode focusMode;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -207,6 +207,7 @@ MainWindow::MainWindow(const QString& filePath, QWidget* parent)
     editor->setEditorCorners((InterfaceStyle) appSettings->getInterfaceStyle());
     editor->setBlockquoteStyle(appSettings->getBlockquoteStyle());
     editor->setSpellCheckEnabled(appSettings->getLiveSpellCheckEnabled());
+    editor->setTypingSoundsEnabled(appSettings->getTypingSoundsEnabled());
     connect(outlineWidget, SIGNAL(documentPositionNavigated(int)), editor, SLOT(navigateDocument(int)));
     connect(editor, SIGNAL(cursorPositionChanged(int)), outlineWidget, SLOT(updateCurrentNavigationHeading(int)));
     connect(editor, SIGNAL(fontSizeChanged(int)), this, SLOT(onFontSizeChanged(int)));
@@ -391,6 +392,7 @@ MainWindow::MainWindow(const QString& filePath, QWidget* parent)
     connect(appSettings, SIGNAL(displayTimeInFullScreenChanged(bool)), this, SLOT(toggleDisplayTimeInFullScreen(bool)));
     connect(appSettings, SIGNAL(dictionaryLanguageChanged(QString)), editor, SLOT(setDictionary(QString)));
     connect(appSettings, SIGNAL(liveSpellCheckChanged(bool)), editor, SLOT(setSpellCheckEnabled(bool)));
+    connect(appSettings, SIGNAL(typingSoundsChanged(bool)), editor, SLOT(setTypingSoundsEnabled(bool)));
     connect(appSettings, SIGNAL(editorWidthChanged(EditorWidth)), this, SLOT(changeEditorWidth(EditorWidth)));
     connect(appSettings, SIGNAL(interfaceStyleChanged(InterfaceStyle)), this, SLOT(changeInterfaceStyle(InterfaceStyle)));
     connect(appSettings, SIGNAL(blockquoteStyleChanged(BlockquoteStyle)), editor, SLOT(setBlockquoteStyle(BlockquoteStyle)));

--- a/src/MarkdownEditor.h
+++ b/src/MarkdownEditor.h
@@ -30,6 +30,7 @@
 #include <QTextCursor>
 #include <QListWidget>
 #include <QRegularExpression>
+#include <QSoundEffect>
 
 #include "GraphicsFadeEffect.h"
 #include "MarkdownEditorTypes.h"
@@ -380,6 +381,11 @@ class MarkdownEditor : public QPlainTextEdit
         void setSpellCheckEnabled(const bool enabled);
 
         /**
+         * Sets whether typing sounds are enabled.
+         */
+        void setTypingSoundsEnabled(const bool enabled);
+
+        /**
          * Increases the font size by 1 pt.
          */
         void increaseFontSize();
@@ -454,6 +460,11 @@ class MarkdownEditor : public QPlainTextEdit
         QTimer* cursorBlinkTimer;
 
         GraphicsFadeEffect* fadeEffect;
+
+        // Sound effects for typing
+        QSoundEffect keySound;
+        QVector<QSoundEffect*> sounds;
+        bool typingSoundsEnabled;
 
         // Timer used to determine when typing has paused.
         QTimer* typingTimer;

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -364,6 +364,18 @@ QWidget* PreferencesDialog::initializeEditorTab()
     connect(matchedCharsButton, SIGNAL(pressed()), this, SLOT(showAutoMatchFilterDialog()));
     typingGroupLayout->addRow(matchedCharsButton);
 
+    QGroupBox* soundsGroupBox = new QGroupBox(tr("Sounds"));
+    tabLayout->addWidget(soundsGroupBox);
+
+    QFormLayout* soundsGroupLayout = new QFormLayout();
+    soundsGroupBox->setLayout(soundsGroupLayout);
+
+    QCheckBox* typingSoundsCheckBox = new QCheckBox(tr("Enable typing sounds"));
+    typingSoundsCheckBox->setCheckable(true);
+    typingSoundsCheckBox->setChecked(appSettings->getTypingSoundsEnabled());
+    connect(typingSoundsCheckBox, SIGNAL(toggled(bool)), appSettings, SLOT(setTypingSoundsEnabled(bool)));
+    soundsGroupLayout->addRow(typingSoundsCheckBox);
+
     return tab;
 }
 


### PR DESCRIPTION
I have added a fun feature some other distraction-free editors have: Typing makes sounds. For me, this does help to keep focus up and motivates.
This implementation is mostly PoC and needs improvement in a lot of places (e.g. different sounds for different keys, don't play sounds for Ctrl, Alt, Shift, ...). To test this, create a folder called "sounds" next to "ghostwriter.exe" and place "key.wav" inside. For testing, I have used "keyany.wav" from focuswriter (https://github.com/gottcode/focuswriter/tree/master/resources/sounds)

Also, to get this to work on Windows I had to add "qt.conf" to the main directory, containing:
```
[Paths]
Prefix=.
Binaries=.
Libraries=.
Plugins=plugins
Imports=imports
Qml2Imports=qml
```

Also, I had to copy Qt's audio plugins (plugins/audio/qtaudio_windows[d].dll) to plugins/audio. I have no experience in deploying Qt whatsoever, so I don't know if this is the usual/prefered way to handle this.

Let me know what you think.