### PR TITLE
Auto build translations when invoking qmake, fix translationsPath for macOS...

### DIFF
--- a/ghostwriter.pro
+++ b/ghostwriter.pro
@@ -212,8 +212,8 @@ SOURCES += src/AppMain.cpp \
     src/sundown/markdown.c \
     src/sundown/stack.c
 
-# Allow for updating translations
-TRANSLATIONS = $$files(translations/ghostwriter_*.ts)
+# build translations
+include(translations.pri)
 
 RESOURCES += resources.qrc
 
@@ -250,7 +250,7 @@ macx {
     man.files = resources/linux/ghostwriter.1
     man.path = $$PREFIX/share/man/man1
 
-    qm.files = translations/*.qm
+    qm.files = $$OUT_PWD/$$DESTDIR/translations/ghostwriter_*.qm
     qm.path = $$DATADIR/ghostwriter/translations
 
     INSTALLS += target icon pixmap desktop appdata man qm

--- a/src/AppSettings.cpp
+++ b/src/AppSettings.cpp
@@ -566,7 +566,12 @@ AppSettings::AppSettings()
             userDir + "/settings"
         );
 
+#ifdef Q_OS_MAC
+        translationsPath = appDir + "../Resources/translations";
+#else
         translationsPath = appDir + "/translations";
+#endif
+
     }
     else
     {

--- a/translations.pri
+++ b/translations.pri
@@ -1,0 +1,58 @@
+message("Building ghostwriter translations, this might take some time")
+
+# Build app translations from .ts sources using lrelease.
+APP_LANGUAGES = cs de en es fr it ja pl pt_BR ru zh 
+APP_TRANSLATIONS_DIR = $$PWD/translations
+
+# Build qt translations from source, if present.
+QT_LANGUAGES = cs de es fr it ja pl ru
+QT_TRANSLATIONS_DIR = $$PWD/qttranslations/translations
+
+# Target dir for translations (inside build dir)
+TRANSLATION_TARGET_DIR = $$OUT_PWD/$$DESTDIR/translations
+!exists($$TRANSLATION_TARGET_DIR) {
+    mkpath($$TRANSLATION_TARGET_DIR)
+}
+
+# set lrelease binary.
+isEmpty(QMAKE_LRELEASE) {
+    win32:L_RELEASE = $$[QT_INSTALL_BINS]\lrelease.exe
+    else:L_RELEASE = $$[QT_INSTALL_BINS]/lrelease
+}
+
+# set lrelease options.
+OPTIONS = "-compress -removeidentical -silent"
+
+# prepend translation name to language.
+defineReplace(prependAll) {
+    for(a,$$1):result += $$2$${a}$$3
+    return($$result)
+}
+
+# application translations
+TRANSLATIONS = $$prependAll(APP_LANGUAGES, $${APP_TRANSLATIONS_DIR}/ghostwriter_, .ts)
+
+# qt translations
+exists($$QT_TRANSLATIONS_DIR) {
+  message("Building qt translations from $$QT_TRANSLATIONS_DIR")
+  TRANSLATIONS += $$prependAll(QT_LANGUAGES, $${QT_TRANSLATIONS_DIR}/qt_, .ts)
+  TRANSLATIONS += $$prependAll(QT_LANGUAGES, $${QT_TRANSLATIONS_DIR}/qtbase_, .ts)
+} else {
+  PATH = $$[QT_INSTALL_TRANSLATIONS]
+  message("Using qt translations from $$PATH")
+  BINARIES += $$prependAll(QT_LANGUAGES, $$PATH/qt_, .qm)
+  BINARIES += $$prependAll(QT_LANGUAGES, $$PATH/qtbase_, .qm)
+}
+
+# build translations using lrelease.
+for(tsfile, TRANSLATIONS) {
+    qmfile = $$TRANSLATION_TARGET_DIR/$$basename(tsfile)
+    qmfile ~= s/.ts$/.qm/
+    system($$L_RELEASE $$OPTIONS $$tsfile -qm $$qmfile)
+}
+
+# copying system binaries.
+for(bin, BINARIES) {
+    qmfile = $$TRANSLATION_TARGET_DIR/$$basename(bin)
+    system(cp -v $$bin $$qmfile)
+}


### PR DESCRIPTION
~~1. Improve translations load logic:
   Find qt translations first in appDir, then in
   QLibraryInfo::TranslationsPath.
   If translation(s) failed to load throw a warning.~~

2. Build translations when calling qmake:
   Translation binaries are copied to DESTDIR.

3. macOS specific:
   translationsPath in ghostwriter.app/Contents/Resources/translations
