### PR TITLE
[work in progress]: add AppImage target for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Makefile*
 *.qm
 
 build/
+
+*.AppImage

--- a/ghostwriter.pro
+++ b/ghostwriter.pro
@@ -55,6 +55,8 @@ UI_DIR = $${DESTDIR}
 
 TARGET = ghostwriter
 
+QMAKE_EXTRA_TARGETS += deploy
+
 # Input
 
 macx {
@@ -87,6 +89,7 @@ macx {
         src/spelling/hunspell/suggestmgr.cxx
 
 } else:unix {
+
 	CONFIG += link_pkgconfig
 	PKGCONFIG += hunspell
 
@@ -254,4 +257,11 @@ macx {
     qm.path = $$DATADIR/ghostwriter/translations
 
     INSTALLS += target icon pixmap desktop appdata man qm
+}
+
+linux {
+    contains(QMAKE_HOST.arch, x86_64) {
+        deploy.commands += $$escape_expand(\n\t) $$PWD/resources/linux/linuxdeploy_helper.sh \
+            $$PWD $$OUT_PWD/$$DESTDIR/AppImage
+    }
 }

--- a/resources/linux/linuxdeploy_helper.sh
+++ b/resources/linux/linuxdeploy_helper.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+tool_name="linuxdeployqt-continuous-x86_64.AppImage"
+
+output="${1}/ghostwriter.appImage"
+
+if [ ! -f "${1}/${tool_name}" ]
+then
+    echo "please download ${tool_name} on ${1} and run this again"
+    exit 1
+else
+    echo "deploying appImage for dir ${2} on ${output}"
+
+    mkdir -pv "$2"
+    pushd "$2"
+    cp -pv ../ghostwriter .
+    cp -pRv ../translations .
+    pushd "$1"
+    chmod +x "${1}/${tool_name}"
+    ./"${tool_name}" "${2}/ghostwriter" "-appimage"
+fi


### PR DESCRIPTION
This PR adds basic support for appImage.(just available for x86_64)

Requires #357 for i18n and #353 (QT += svg, used to fetch libraries by windeployqt, macdeployqt & linuxdeployqt)

Need a concept ACK before fine tuning (adding icon, desktop file). 









