### PR TITLE
Older Pandoc releases like in Debian 9 don't know the option --quiet

### DIFF
--- a/src/ExporterFactory.cpp
+++ b/src/ExporterFactory.cpp
@@ -394,12 +394,26 @@ void ExporterFactory::addPandocExporter
             " -t html"
     );
 
-    QString standardExportStr =
-        QString("pandoc -f ") +
-        inputFormat +
-        CommandLineExporter::SMART_TYPOGRAPHY_ARG +
-        " -t %1 --standalone --quiet -o " +
-        CommandLineExporter::OUTPUT_FILE_PATH_VAR;
+    QString standardExportStr;
+    if ( (majorVersion > 1) || ((1 == majorVersion) && (minorVersion > 17)) )
+    {
+        standardExportStr =
+            QString("pandoc -f ") +
+            inputFormat +
+            CommandLineExporter::SMART_TYPOGRAPHY_ARG +
+            " -t %1 --standalone --quiet -o " +
+            CommandLineExporter::OUTPUT_FILE_PATH_VAR;
+    }
+    else
+    {
+        // older Pandoc releases like in Debian 9 don't know the option '--quiet'
+        standardExportStr =
+            QString("pandoc -f ") +
+            inputFormat +
+            CommandLineExporter::SMART_TYPOGRAPHY_ARG +
+            " -t %1 --standalone -o " +
+            CommandLineExporter::OUTPUT_FILE_PATH_VAR;
+    }
 
     exporter->addFileExportCommand
     (


### PR DESCRIPTION
I'm using Ghostwriter with Debian 9. Here the Pandoc has the ancient release 1.17.2. This release ins't aware of the option `--quiet`.

I've added a `if-else` to `ExporterFactory` to add the option only for newer Pandoc releases.