### PR TITLE
Fix broken icon when run under Wayland

### DIFF
--- a/src/AppMain.cpp
+++ b/src/AppMain.cpp
@@ -32,6 +32,10 @@ int main(int argc, char* argv[])
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
+#if QT_VERSION >= 0x050700 && defined(Q_OS_LINUX)
+    QGuiApplication::setDesktopFileName("ghostwriter");
+#endif
+
     QApplication app(argc, argv);
 
     // Call this to force settings initialization before the application


### PR DESCRIPTION
Otherwise, a generic Wayland icon is shown in the title bar.

The Flatpak manifest will need to be adapted like this:
```
{
                    "type": "shell",
                    "commands": ["sed -e 's|setDesktopFileName(\"ghostwriter\")|setDesktopFileName(\"io.github.wereturtle.ghostwriter\")|\' -i src/AppMain.cpp"]
}
```