### PR TITLE
Little fix: make install must be done as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Next, open a terminal window, and enter the following commands:
     $ cd <your_ghostwriter_folder_location>
     $ qmake
     $ make
-    $ make install
+    # make install
 
 The last command will install *ghostwriter* on your machine.  If you need to install the application in an alternative location to `/usr/local`, enter the following command in lieu of the second command above, passing in the desired value for `PREFIX`:
 


### PR DESCRIPTION
I changed the prompt symbol to advice that `make install` must be executed as root user