### PR TITLE
Enhancement - Loading Last File Optional

### DIFF
--- a/src/AppSettings.cpp
+++ b/src/AppSettings.cpp
@@ -34,6 +34,7 @@
 #define GW_AUTOSAVE_KEY "Save/autoSave"
 #define GW_BACKUP_FILE_KEY "Save/backupFile"
 #define GW_REMEMBER_FILE_HISTORY_KEY "Save/rememberFileHistory"
+#define GW_LOAD_LAST_FILE_KEY "Save/loadLastFile"
 #define GW_FONT_KEY "Style/font"
 #define GW_LARGE_HEADINGS_KEY "Style/largeHeadings"
 #define GW_HIGHLIGHT_LINE_BREAKS "Style/highlightLineBreaks"
@@ -99,6 +100,7 @@ void AppSettings::store()
     appSettings.setValue(GW_FOCUS_MODE_KEY, QVariant(focusMode));
     appSettings.setValue(GW_HIDE_MENU_BAR_IN_FULL_SCREEN_KEY, QVariant(hideMenuBarInFullScreenEnabled));
     appSettings.setValue(GW_REMEMBER_FILE_HISTORY_KEY, QVariant(fileHistoryEnabled));
+    appSettings.setValue(GW_LOAD_LAST_FILE_KEY, QVariant(loadLastFileEnabled));
     appSettings.setValue(GW_DISPLAY_TIME_IN_FULL_SCREEN_KEY, QVariant(displayTimeInFullScreenEnabled));
     appSettings.setValue(GW_HIDE_HUDS_WHEN_TYPING_KEY, QVariant(hideHudsWhenTypingEnabled));
     appSettings.setValue(GW_HIDE_HUDS_ON_PREVIEW_KEY, QVariant(hideHudsOnPreviewEnabled));
@@ -312,6 +314,17 @@ void AppSettings::setFileHistoryEnabled(bool enabled)
 {
     fileHistoryEnabled = enabled;
     emit fileHistoryChanged(enabled);
+}
+
+bool AppSettings::getLoadLastFileEnabled() const
+{
+    return loadLastFileEnabled;
+}
+
+void AppSettings::setLoadLastFileEnabled(bool enabled)
+{
+    loadLastFileEnabled = enabled;
+    emit loadLastFileChanged(enabled);
 }
 
 bool AppSettings::getDisplayTimeInFullScreenEnabled()
@@ -732,6 +745,7 @@ AppSettings::AppSettings()
 
     hideMenuBarInFullScreenEnabled = appSettings.value(GW_HIDE_MENU_BAR_IN_FULL_SCREEN_KEY, QVariant(true)).toBool();
     fileHistoryEnabled = appSettings.value(GW_REMEMBER_FILE_HISTORY_KEY, QVariant(true)).toBool();
+    loadLastFileEnabled = appSettings.value(GW_LOAD_LAST_FILE_KEY, QVariant(true)).toBool();
     displayTimeInFullScreenEnabled = appSettings.value(GW_DISPLAY_TIME_IN_FULL_SCREEN_KEY, QVariant(true)).toBool();
     hideHudsWhenTypingEnabled = appSettings.value(GW_HIDE_HUDS_WHEN_TYPING_KEY, QVariant(false)).toBool();
     hideHudsOnPreviewEnabled = appSettings.value(GW_HIDE_HUDS_ON_PREVIEW_KEY, QVariant(false)).toBool();

--- a/src/AppSettings.h
+++ b/src/AppSettings.h
@@ -104,6 +104,10 @@ class AppSettings : public QObject
         bool getFileHistoryEnabled() const;
         Q_SLOT void setFileHistoryEnabled(bool enabled);
         Q_SIGNAL void fileHistoryChanged(bool enabled);
+        
+        bool getLoadLastFileEnabled() const;
+        Q_SLOT void setLoadLastFileEnabled(bool enabled);
+        Q_SIGNAL void loadLastFileChanged(bool enabled);
 
         bool getDisplayTimeInFullScreenEnabled();
         Q_SLOT void setDisplayTimeInFullScreenEnabled(bool enabled);
@@ -189,6 +193,7 @@ class AppSettings : public QObject
         QFont defaultFont;
         bool autoSaveEnabled;
         bool backupFileEnabled;
+        bool loadLastFileEnabled;
         QFont font;
         int tabWidth;
         bool insertSpacesForTabsEnabled;

--- a/src/DocumentManager.cpp
+++ b/src/DocumentManager.cpp
@@ -61,7 +61,7 @@ DocumentManager::DocumentManager
     : QObject(parent), parentWidget(parent), editor(editor),
         outline(outline), documentStats(documentStats),
         sessionStats(sessionStats), fileHistoryEnabled(true),
-        createBackupOnSave(true), saveInProgress(false),
+        createBackupOnSave(true), loadLastFileEnabled(true), saveInProgress(false),
         autoSaveEnabled(false), documentModifiedNotifVisible(false)
 {
     saveFutureWatcher = new QFutureWatcher<QString>(this);
@@ -110,6 +110,11 @@ bool DocumentManager::getFileBackupEnabled() const
 void DocumentManager::setFileHistoryEnabled(bool enabled)
 {
     fileHistoryEnabled = enabled;
+}
+
+void DocumentManager::setLoadLastFileEnabled(bool enabled)
+{
+    loadLastFileEnabled = enabled;
 }
 
 void DocumentManager::setAutoSaveEnabled(bool enabled)

--- a/src/DocumentManager.h
+++ b/src/DocumentManager.h
@@ -81,6 +81,11 @@ class DocumentManager : public QObject
          * Gets whether tracking the recent file history is enabled.
          */
         void setFileHistoryEnabled(bool enabled);
+        
+        /**
+         * Gets whether loading last file is enabled.        
+         */
+        void setLoadLastFileEnabled(bool enabled);
 
     signals:
         /**
@@ -225,6 +230,7 @@ class DocumentManager : public QObject
         QFileSystemWatcher* fileWatcher;
         bool fileHistoryEnabled;
         bool createBackupOnSave;
+        bool loadLastFileEnabled;
 
         /*
          * This flag is used to prevent notifying the user that the document

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -252,6 +252,7 @@ MainWindow::MainWindow(const QString& filePath, QWidget* parent)
     documentManager->setAutoSaveEnabled(appSettings->getAutoSaveEnabled());
     documentManager->setFileBackupEnabled(appSettings->getBackupFileEnabled());
     documentManager->setFileHistoryEnabled(appSettings->getFileHistoryEnabled());
+    documentManager->setLoadLastFileEnabled(appSettings->getLoadLastFileEnabled());
     setWindowTitle(documentManager->getDocument()->getDisplayName() + "[*] - " + qAppName());
     connect(documentManager, SIGNAL(documentDisplayNameChanged(QString)), this, SLOT(changeDocumentDisplayName(QString)));
     connect(documentManager, SIGNAL(documentModifiedChanged(bool)), this, SLOT(setWindowModified(bool)));
@@ -313,7 +314,7 @@ MainWindow::MainWindow(const QString& filePath, QWidget* parent)
         }
     }
 
-    if (fileToOpen.isNull() && appSettings->getFileHistoryEnabled())
+    if (fileToOpen.isNull() && appSettings->getFileHistoryEnabled() && appSettings->getLoadLastFileEnabled())
     {
         QString lastFile;
 
@@ -390,6 +391,7 @@ MainWindow::MainWindow(const QString& filePath, QWidget* parent)
     connect(appSettings, SIGNAL(focusModeChanged(FocusMode)), this, SLOT(changeFocusMode(FocusMode)));
     connect(appSettings, SIGNAL(hideMenuBarInFullScreenChanged(bool)), this, SLOT(toggleHideMenuBarInFullScreen(bool)));
     connect(appSettings, SIGNAL(fileHistoryChanged(bool)), this, SLOT(toggleFileHistoryEnabled(bool)));
+    connect(appSettings, SIGNAL(loadLastFileChanged(bool)), this, SLOT(toggleLoadLastFileEnabled(bool)));
     connect(appSettings, SIGNAL(displayTimeInFullScreenChanged(bool)), this, SLOT(toggleDisplayTimeInFullScreen(bool)));
     connect(appSettings, SIGNAL(dictionaryLanguageChanged(QString)), editor, SLOT(setDictionary(QString)));
     connect(appSettings, SIGNAL(liveSpellCheckChanged(bool)), editor, SLOT(setSpellCheckEnabled(bool)));
@@ -947,6 +949,11 @@ void MainWindow::toggleFileHistoryEnabled(bool checked)
     }
 
     documentManager->setFileHistoryEnabled(checked);
+}
+
+void MainWindow::toggleLoadLastFileEnabled(bool checked)
+{
+    documentManager->setLoadLastFileEnabled(checked);
 }
 
 void MainWindow::toggleDisplayTimeInFullScreen(bool checked)

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -85,6 +85,7 @@ class MainWindow : public QMainWindow
         void toggleHideMenuBarInFullScreen(bool checked);
         void toggleOutlineAlternateRowColors(bool checked);
         void toggleFileHistoryEnabled(bool checked);
+        void toggleLoadLastFileEnabled(bool checked);
         void toggleDisplayTimeInFullScreen(bool checked);
         void toggleDesktopCompositingEffects(bool checked);
         void toggleOpenHudsVisibility();

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -251,6 +251,12 @@ QWidget* PreferencesDialog::initializeGeneralTab()
     rememberHistoryCheckBox->setChecked(appSettings->getFileHistoryEnabled());
     connect(rememberHistoryCheckBox, SIGNAL(toggled(bool)), appSettings, SLOT(setFileHistoryEnabled(bool)));
     historyGroupLayout->addRow(rememberHistoryCheckBox);
+    
+    QCheckBox* loadLastFileCheckBox = new QCheckBox(tr("On start, load last file edited"));
+    loadLastFileCheckBox->setCheckable(true);
+    loadLastFileCheckBox->setChecked(appSettings->getLoadLastFileEnabled());
+    connect(loadLastFileCheckBox, SIGNAL(toggled(bool)), appSettings, SLOT(setLoadLastFileEnabled(bool)));
+    historyGroupLayout->addRow(loadLastFileCheckBox);
 
     return tab;
 }


### PR DESCRIPTION
Updated to include new feature, which makes loading the last file edited optional as per issue #135 . If the option is on, the last file _edited_ (not necessarily the last file open, i.e. a blank document will not reopen on start per issue #255 ) is opened on start. If option is off, a new, blank document is opened when ghostwriter starts.