### PR TITLE
fix appdata

### DIFF
--- a/resources/linux/ghostwriter.appdata.xml
+++ b/resources/linux/ghostwriter.appdata.xml
@@ -26,7 +26,8 @@
   <provides>
     <binary>ghostwriter</binary>
   </provides>
+  <content_rating type="oars-1.1"/>
   <releases>
-    <release version="1.8.1" date="20200222" type="stable"/>
+    <release version="1.8.1" date="2020-02-22" type="stable"/>
   </releases>
 </component>


### PR DESCRIPTION
```
$ flatpak run org.freedesktop.appstream-glib validate ghostwriter.appdata.xml
ghostwriter.appdata.xml: FAILED:
• tag-missing           : <content_rating> required [use https://odrs.gnome.org/oars]
• attribute-missing     : <release> has no timestamp
Validation of files failed

```
This why the 1.8.1 build failed and 1.8.0 is still current version on Flathub:
https://flathub.org/builds/#/builders/12/builds/1827