### PR TITLE
Fix build error with Qt 5.15

### DIFF
--- a/src/MarkdownEditor.cpp
+++ b/src/MarkdownEditor.cpp
@@ -30,6 +30,7 @@
 #include <QMenu>
 #include <QMimeData>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPixmap>
 #include <QScreen>
 #include <QScrollBar>


### PR DESCRIPTION
I know you don’t normally do PRs, but this one is extremely straightforward and I need this change for the AUR package of ghostwriter. It fixes a build error that appeared with Qt 5.15, caused by a missing include.