### PR TITLE
Do not auto-add a closing character if the next character is not whitespace

### DIFF
--- a/src/MarkdownEditor.cpp
+++ b/src/MarkdownEditor.cpp
@@ -2081,6 +2081,16 @@ bool MarkdownEditor::insertPairedCharacters(const QChar firstChar)
                 }
             }
 
+            // If we are not at the end of the block
+            // and the next character is not whitespace,
+            // most likely the user is either manually adding a pair of
+            // characters around some text,
+            // or there's no need for a closing character at all.
+            if (!cursor.atBlockEnd() && !cursor.block().text()[blockPos + 1].isSpace())
+            {
+                doMatch = false;
+            }
+
             if (doMatch)
             {
                 cursor.insertText(firstChar);


### PR DESCRIPTION
I love ghostwriter, but there's one thing that is driving me mad. Adding a matching character is a nice feature except in one case its heuristic is, in my opinion, wrong.

There are cases when it works like a charm:
* The user selects some text and types a `(` — no doubt, they want the selected text enclosed in parens.
* The user is at the end of a block or in the middle of a whitespace and types a `(` — most likely they are starting a parenthesized phrase.

Now suppose a user is at a word boundary (right before a non-whitespace character) and types a `(` or another character from the auto-closing character list.

There are two cases:
* Either the user forgot to add it before and wants to add those characters completely by hand, for whatever reason.
* Or the character is actually a part of the word (e.g. 'Ndrangheta, *nix).

In any case, `foo` turning into a `**foo` when a user puts the cursor before "foo" and types a "*" most likely isn't what a user wants, as of me.

This patch corrects it by auto-closing paired characters only if the user is at the end of a block or in the middle of some whitespace.

Maybe this should rather be made a configurable option, I'm open for discussion.