### PR TITLE
Don't fail if MathJax is unavailable

### DIFF
--- a/resources/gw.js
+++ b/resources/gw.js
@@ -77,7 +77,7 @@ var updateText = function(text) {
     insertAnchorsForHeadings();
 
     // Call MathJax to update document, if the library is available.
-    if (typeof window.MathJax.typeset !== 'undefined') {
+    if (typeof window.MathJax !== 'undefined') {
         window.MathJax.typeset();
     }
 


### PR DESCRIPTION
This fixes the following error:
`js: Uncaught TypeError: Cannot read property 'typeset' of undefined`