### PR TITLE
Fix #619, Chinese preview in HTML is complete now. Update README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ For Debian or Ubuntu distributions:
 
 For Fedora:
 
-    $ sudo dnf install qt-devel qt5-qtbase-devel qt5-qtsvg-devel qt5-qtmultimedia-devel qt5-qtwebengine-devel hunspell-devel
+    $ sudo dnf install qt-devel qt5-qtbase-devel qt5-qtsvg-devel qt5-qtmultimedia-devel qt5-qtwebengine-devel hunspell-devel qt5-linguist
 
 For other Linux flavors, the list will be similar; `qmake` will tell you if you are missing anything.
 
 Next, open a terminal window, and enter the following commands:
 
     $ cd <your_ghostwriter_folder_location>
-    $ qmake
+    $ qmake-qt5
     $ make
     # make install
 

--- a/src/cmarkgfmapi.cpp
+++ b/src/cmarkgfmapi.cpp
@@ -93,7 +93,7 @@ MarkdownAST *CmarkGfmAPI::parse(const QString &text, const bool smartTypographyE
     // the nodes returned in the AST are shifted or missing when
     // UTF-8 characters longer than 1 byte are encountered.
     //
-    cmark_parser_feed(parser, text.toLatin1().data(), text.length());
+    cmark_parser_feed(parser, text.toLatin1().data(), text.toLocal8Bit().length());
 
     cmark_node *root = cmark_parser_finish(parser);
     MarkdownAST *ast = new MarkdownAST(root);
@@ -127,7 +127,7 @@ QString CmarkGfmAPI::renderToHtml(const QString &text, const bool smartTypograph
     cmark_parser_attach_syntax_extension(parser, d->tagfilterExt);
     cmark_parser_attach_syntax_extension(parser, d->tasklistExt);
 
-    cmark_parser_feed(parser, text.toUtf8().data(), text.length());
+    cmark_parser_feed(parser, text.toUtf8().data(), text.toLocal8Bit().length());
 
     cmark_node *root = cmark_parser_finish(parser);
     char *output = cmark_render_html(root, opts, cmark_parser_get_syntax_extensions(parser));


### PR DESCRIPTION
Add necessary package "qt5-linguist" for Fedora.
Replace Linux build command "qmake" with "qmake-qt5".