### PR TITLE
Correct the date format and type

### DIFF
--- a/resources/linux/ghostwriter.appdata.xml
+++ b/resources/linux/ghostwriter.appdata.xml
@@ -28,6 +28,6 @@
   </provides>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="2.0.1" date="20210516" type="release"/>
+    <release version="2.0.1" date="2021-05-16" type="stable"/>
   </releases>
 </component>


### PR DESCRIPTION
The type must be stable or development
The date format must be ISO 8601

See : https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases