### PR TITLE
removing bug reports section as bug reports are not accepted anymore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,5 @@
 # Contributing
 
-## Bug Reports
-
-Bug reports are the number one way you can contribute to *ghostwriter*.  Please include the following information when filing a bug report in GitHub:
-
-* Your Operating System
-* If on GNU/Linux, your desktop environment
-* Steps that can be used to replicate the problem
-* Any sample Markdown files that might be useful in replicating the problem
-
 ## New Feature Requests
 
 At this present time, I do not have the bandwidth to work on new feature requests.  As such, new feature requests filed in GitHub will be closed.  This does not mean *ghostwriter* will cease to have new features.  On the contrary!  *ghostwriter* has quite the backlog of feature requests already filed in GitHub.  Also, I have a secret list of features I would like to work on that I think the community will very much enjoy.  I do appreciate the community's enthusiasm for *ghostwriter*.  Thank you for all your feedback!


### PR DESCRIPTION
If you accept bug reports using some other method it may be useful to rather add this info there somehow.

BTW, http://wereturtle.github.io/ghostwriter/ is partially broken (unless it is some in-joke)

![screen02](https://user-images.githubusercontent.com/899988/140518292-002bc566-0f17-4b9c-a0af-9f5a99f22d1d.png)
