### PR TITLE
Added a workaround to prevent empty draft files from being saved to disk

### DIFF
--- a/C_Make_WIP.txt
+++ b/C_Make_WIP.txt
@@ -74,6 +74,7 @@ set(ghostwriter_SOURCES
   src/sessionstatisticswidget.cpp
   src/sidebar.cpp
   src/simplefontdialog.cpp
+  src/statisticsindicator.cpp
   src/stringobserver.cpp
   src/stylesheetbuilder.cpp
   src/textblockdata.cpp
@@ -124,6 +125,7 @@ set(ghostwriter_HEADERS
   src/sessionstatisticswidget.h
   src/sidebar.h
   src/simplefontdialog.h
+  src/statisticsindicator.h
   src/stringobserver.h
   src/stylesheetbuilder.h
   src/textblockdata.h

--- a/src/documentmanager.cpp
+++ b/src/documentmanager.cpp
@@ -1005,6 +1005,10 @@ bool DocumentManagerPrivate::documentIsDraft()
 
 void DocumentManagerPrivate::createDraft()
 {
+    // TODO: This is a workaround to prevent extra empty drafts from being created when user closes application #696
+    if (document->isEmpty()) {
+        return;
+    }
     if (document->isNew()) {
         int i = 1;
         QString draftPath;
@@ -1019,5 +1023,4 @@ void DocumentManagerPrivate::createDraft()
         saveFile();
     }
 }
-
 }

--- a/src/documentmanager.cpp
+++ b/src/documentmanager.cpp
@@ -231,7 +231,7 @@ DocumentManager::DocumentManager
             if (modified
                     && d->autoSaveEnabled 
                     && d->document->isNew()
-                    && (d->document->characterCount() > 0)) {
+                    && (!d->document->isEmpty())) {
                 d->createDraft();
             }
         }
@@ -281,7 +281,7 @@ void DocumentManager::setAutoSaveEnabled(bool enabled)
 
     if (enabled) {
         if (d->document->isNew()
-            && (d->document->characterCount() > 0)
+            && (!d->document->isEmpty())
             && d->document->isModified()) {
             d->createDraft();
         }
@@ -1005,10 +1005,6 @@ bool DocumentManagerPrivate::documentIsDraft()
 
 void DocumentManagerPrivate::createDraft()
 {
-    // TODO: This is a workaround to prevent extra empty drafts from being created when user closes application #696
-    if (document->isEmpty()) {
-        return;
-    }
     if (document->isNew()) {
         int i = 1;
         QString draftPath;
@@ -1023,4 +1019,5 @@ void DocumentManagerPrivate::createDraft()
         saveFile();
     }
 }
+
 }


### PR DESCRIPTION
* Added missing reference to  statisticsindicator.cpp/.h which prevented CMake from building project. ( Sorry, normally I would make a separate PR, but I already had this small fix committed without realizing)
* Added a workaround Fix #696 to prevent empty draft files from being saved to disk.