### PR TITLE
Fix build issues (windows), add markup "auto-close" to better emulate standard text editor behavior

### DIFF
--- a/src/appmain.cpp
+++ b/src/appmain.cpp
@@ -62,15 +62,15 @@ int main(int argc, char *argv[])
         bool ok = false;
 
         if (translatorStr != "ghostwriter") {
+            const QString& translation_loc = 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            ok = qtTranslator.load(translatorStr + "_" + appSettings->locale(),
-                                        QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+                QLibraryInfo::location(QLibraryInfo::TranslationsPath);
 #else
-            ok = translator.load(translatorStr + "_" + appSettings->locale(),
-                                        QLibraryInfo::path(QLibraryInfo::TranslationsPath));
+                QLibraryInfo::path(QLibraryInfo::TranslationsPath);
 #endif
+            ok = translator.load(translatorStr + "_" + appSettings->locale(),
+                                        translation_loc);        
         }
-
         if (!ok) {
             ok = translator.load(translatorStr + "_" + appSettings->locale(),
                               appSettings->translationsPath());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -458,7 +458,11 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
             this->menuBar()->hide();
         } else if (QEvent::MouseMove == event->type()) {
             QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            if ((mouseEvent->globalPos().y()) <= 0 && !this->menuBar()->isVisible()) {
+#else
             if ((mouseEvent->globalPosition().y()) <= 0 && !this->menuBar()->isVisible()) {
+#endif
                 this->menuBar()->show();
             }
         } else if ((this == obj) 


### PR DESCRIPTION
### Changes

Fix some build issues I experienced on Windows and Fedora:

1. `qtTranslator` is not a valid variable, I expect this may have been an issue during refactoring. Changed this block in `appmain.cpp` to use a single call to `translator.load()`, while preserving Qt version compatibility. 
2. `QMouseEvent::globalPosition()` is not a valid function (named `globalPos()` instead), at least for the versions of Qt 5 shipped with Fedora and available for Download from Qt on Windows. This may have been changed with Qt 6 (or perhaps only exists in certain versions of Qt5?), so I added a preprocessor check.

I expect these ^ fixes may fix the Fedora and Ubuntu build pipelines.

I also added functionality to the markdown editor where if the user sets a bold/italic/strikethrough markup, if the cursor is at the end (but *inside*) an existing markup chunk, it will move the cursor beyond the terminating markup rather than insert a new one.

This "auto-closes" a bold/italic/strikethrough block, so the user does not have to manually move the cursor over.

E.g.,:

`This is some **text with[CURSOR]** some bold text`

Ctrl+B

`This is some **text with**[CURSOR] some bold text`

For me, this is easier... I can simply Ctrl+B to start a bold chunk, type what I want, and then Ctrl+B again to end it.

Perhaps this can be made a toggle-able setting in the Preferences.

---
### Thoughts for additional changes: 

It may also be worthwhile to add functionality to toggle a markup chunk if the cursor is at the end and *outside* the chunk.

E.g.:

`This is some **text with**[CURSOR] some bold text`

If the user types "Ctrl+B" in this instance, it will toggle-off the preceding markup, leaving:

`This is some text with some bold text`.

To toggle back on, the position of the markup start point would need to be cached until the user moves the cursor again.