### PR TITLE
Fixed build on fedora and windows

### DIFF
--- a/src/appmain.cpp
+++ b/src/appmain.cpp
@@ -62,15 +62,15 @@ int main(int argc, char *argv[])
         bool ok = false;
 
         if (translatorStr != "ghostwriter") {
+            const QString& translation_loc = 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            ok = qtTranslator.load(translatorStr + "_" + appSettings->locale(),
-                                        QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+                QLibraryInfo::location(QLibraryInfo::TranslationsPath);
 #else
-            ok = translator.load(translatorStr + "_" + appSettings->locale(),
-                                        QLibraryInfo::path(QLibraryInfo::TranslationsPath));
+                QLibraryInfo::path(QLibraryInfo::TranslationsPath);
 #endif
+            ok = translator.load(translatorStr + "_" + appSettings->locale(),
+                                        translation_loc);        
         }
-
         if (!ok) {
             ok = translator.load(translatorStr + "_" + appSettings->locale(),
                               appSettings->translationsPath());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -458,7 +458,11 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
             this->menuBar()->hide();
         } else if (QEvent::MouseMove == event->type()) {
             QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            if ((mouseEvent->globalPos().y()) <= 0 && !this->menuBar()->isVisible()) {
+#else
             if ((mouseEvent->globalPosition().y()) <= 0 && !this->menuBar()->isVisible()) {
+#endif
                 this->menuBar()->show();
             }
         } else if ((this == obj) 


### PR DESCRIPTION
### Changes

Fix some build issues I experienced on Windows and Fedora:

1. `qtTranslator` is not a valid variable, I expect this may have been an issue during refactoring. Changed this block in `appmain.cpp` to use a single call to `translator.load()`, while preserving Qt version compatibility. 
2. `QMouseEvent::globalPosition()` is not a valid function (named `globalPos()` instead), at least for the versions of Qt 5 shipped with Fedora and available for Download from Qt on Windows. This may have been changed with Qt 6 (or perhaps only exists in certain versions of Qt5?), so I added a preprocessor check.

I expect these ^ fixes may fix the Fedora and Ubuntu build pipelines.