### PR TITLE
Add scroll past end preference

### DIFF
--- a/src/appmain.cpp
+++ b/src/appmain.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
 
         if (translatorStr != "ghostwriter") {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            ok = qtTranslator.load(translatorStr + "_" + appSettings->locale(),
+            ok = translator.load(translatorStr + "_" + appSettings->locale(),
                                         QLibraryInfo::location(QLibraryInfo::TranslationsPath));
 #else
             ok = translator.load(translatorStr + "_" + appSettings->locale(),

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -46,6 +46,7 @@
 #define GW_UNDERLINE_ITALICS_KEY "Style/underlineInsteadOfItalics"
 #define GW_FOCUS_MODE_KEY "Style/focusMode"
 #define GW_HIDE_MENU_BAR_IN_FULL_SCREEN_KEY "Style/hideMenuBarInFullScreenEnabled"
+#define GW_SCROLL_PAST_END_KEY "Style/ScrollPastEnd"
 #define GW_THEME_KEY "Style/theme"
 #define GW_DARK_MODE_KEY "Style/darkModeEnabled"
 #define GW_EDITOR_WIDTH_KEY "Style/editorWidth"
@@ -114,6 +115,7 @@ public:
     QString themeDirectoryPath;
     QString themeName;
     bool darkModeEnabled;
+    bool scrollPastEnd;
     QString translationsPath;
 };
 
@@ -168,6 +170,7 @@ void AppSettings::store()
     appSettings.setValue(GW_THEME_KEY, QVariant(d->themeName));
     appSettings.setValue(GW_DARK_MODE_KEY, QVariant(d->darkModeEnabled));
     appSettings.setValue(GW_UNDERLINE_ITALICS_KEY, QVariant(d->useUnderlineForEmphasis));
+    appSettings.setValue(GW_SCROLL_PAST_END_KEY, QVariant(d->scrollPastEnd));
 
     appSettings.sync();
 }
@@ -349,6 +352,21 @@ void AppSettings::setAutoMatchEnabled(bool enabled)
     
     d->autoMatchEnabled = enabled;
     emit autoMatchChanged(enabled);
+}
+
+bool AppSettings::scrollPastEnd() const
+{
+    Q_D(const AppSettings);
+
+    return d->scrollPastEnd;
+}
+
+void AppSettings::setScrollPastEnd(bool enabled)
+{
+    Q_D(AppSettings);
+
+    d->scrollPastEnd = enabled;
+    emit scrollPastEndChanged(enabled);
 }
 
 bool AppSettings::autoMatchCharEnabled(const QChar openingCharacter) const
@@ -818,6 +836,7 @@ AppSettings::AppSettings()
     d->autoMatchedCharFilter = appSettings.value(GW_AUTO_MATCH_FILTER_KEY, QVariant("\"\'([{*_`<")).toString();
     d->bulletPointCyclingEnabled = appSettings.value(GW_BULLET_CYCLING_KEY, QVariant(true)).toBool();
     d->focusMode = (FocusMode) appSettings.value(GW_FOCUS_MODE_KEY, QVariant(FocusModeSentence)).toInt();
+    d->scrollPastEnd = appSettings.value(GW_SCROLL_PAST_END_KEY, QVariant(true)).toBool();
 
     if ((d->focusMode < FocusModeFirst) || (d->focusMode > FocusModeLast)) {
         d->focusMode = FocusModeSentence;

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -97,6 +97,10 @@ public:
     Q_SLOT void setAutoMatchEnabled(bool enabled);
     Q_SIGNAL void autoMatchChanged(bool enabled);
 
+    bool scrollPastEnd() const;
+    Q_SLOT void setScrollPastEnd(bool enabled);
+    Q_SIGNAL void scrollPastEndChanged(bool enabled);
+
     bool autoMatchCharEnabled(const QChar openingCharacter) const;
     Q_SLOT void setAutoMatchCharEnabled(const QChar openingCharacter, bool enabled);
     Q_SIGNAL void autoMatchCharChanged(const QChar openingChar, bool enabled);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -107,6 +107,7 @@ MainWindow::MainWindow(const QString &filePath, QWidget *parent)
     editor->setItalicizeBlockquotes(appSettings->italicizeBlockquotes());
     editor->setTabulationWidth(appSettings->tabWidth());
     editor->setInsertSpacesForTabs(appSettings->insertSpacesForTabsEnabled());
+    editor->setScrollPastEnd(appSettings->scrollPastEnd());
 
     connect(editor,
         &MarkdownEditor::fontSizeChanged,
@@ -252,6 +253,7 @@ MainWindow::MainWindow(const QString &filePath, QWidget *parent)
     connect(appSettings, SIGNAL(interfaceStyleChanged(InterfaceStyle)), this, SLOT(changeInterfaceStyle(InterfaceStyle)));
     connect(appSettings, SIGNAL(previewTextFontChanged(QFont)), this, SLOT(applyTheme()));
     connect(appSettings, SIGNAL(previewCodeFontChanged(QFont)), this, SLOT(applyTheme()));
+    connect(appSettings, SIGNAL(scrollPastEndChanged(bool)), editor, SLOT(setScrollPastEnd(bool)));
 
     if (this->isFullScreen() && appSettings->hideMenuBarInFullScreenEnabled()) {
         this->menuBar()->hide();
@@ -458,7 +460,11 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
             this->menuBar()->hide();
         } else if (QEvent::MouseMove == event->type()) {
             QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+            if ((mouseEvent->globalPos().y()) <= 0 && !this->menuBar()->isVisible()) {
+#else
             if ((mouseEvent->globalPosition().y()) <= 0 && !this->menuBar()->isVisible()) {
+#endif
                 this->menuBar()->show();
             }
         } else if ((this == obj) 

--- a/src/markdowneditor.cpp
+++ b/src/markdowneditor.cpp
@@ -94,6 +94,7 @@ public:
     QColor blockColor;
     bool insertSpacesForTabs;
     int tabWidth;
+    bool scrollPastEnd;
     EditorWidth editorWidth;
     InterfaceStyle editorCorners;
     QRegularExpression emptyBlockquoteRegex;
@@ -177,6 +178,7 @@ MarkdownEditor::MarkdownEditor
     d->autoMatchEnabled = true;
     d->bulletPointCyclingEnabled = true;
     d->mouseButtonDown = false;
+    d->scrollPastEnd = true;
 
     this->setDocument(textDocument);
     this->setAcceptDrops(true);
@@ -1245,6 +1247,15 @@ void MarkdownEditor::setAutoMatchEnabled(const QChar openingCharacter, bool enab
     Q_D(MarkdownEditor);
     
     d->autoMatchFilter.insert(openingCharacter, enabled);
+}
+
+void MarkdownEditor::setScrollPastEnd(bool enable)
+{
+    Q_D(MarkdownEditor);
+
+    d->scrollPastEnd = enable;
+
+    this->setCenterOnScroll(d->scrollPastEnd);
 }
 
 void MarkdownEditor::setBulletPointCyclingEnabled(bool enable)

--- a/src/markdowneditor.h
+++ b/src/markdowneditor.h
@@ -303,6 +303,11 @@ public slots:
     void setAutoMatchEnabled(const QChar openingCharacter, bool enabled);
 
     /**
+     * Sets whether the window can be scrolled to fill the screen with blank space
+     */
+    void setScrollPastEnd(bool enable);
+
+    /**
      * Sets whether bullet points should be automatically cycled with
      * a different bullet point mark (*, -, +) each time a sublist is
      * created.

--- a/src/preferencesdialog.cpp
+++ b/src/preferencesdialog.cpp
@@ -208,6 +208,12 @@ QWidget *PreferencesDialogPrivate::initializeGeneralTab()
     connect(menuBarCheckBox, SIGNAL(toggled(bool)), appSettings, SLOT(setHideMenuBarInFullScreenEnabled(bool)));
     displayGroupLayout->addRow(menuBarCheckBox);
 
+    QCheckBox *scrollPastEndCheckbox = new QCheckBox(tr("Scroll past end"));
+    scrollPastEndCheckbox->setCheckable(true);
+    scrollPastEndCheckbox->setChecked(appSettings->scrollPastEnd());
+    connect(scrollPastEndCheckbox, SIGNAL(toggled(bool)), appSettings, SLOT(setScrollPastEnd(bool)));
+    displayGroupLayout->addRow(scrollPastEndCheckbox);
+
     QComboBox *cornersComboBox = new QComboBox(q);
     cornersComboBox->addItem(tr("Rounded"), QVariant(InterfaceStyleRounded));
     cornersComboBox->addItem(tr("Square"), QVariant(InterfaceStyleSquare));


### PR DESCRIPTION
## Preamble

Hi, I saw this:

https://github.com/wereturtle/ghostwriter/blob/a144b6c74f80786092d2627a1e5bfe527cd12345/CONTRIBUTING.md?plain=1#L15-L19

... which is sad, but I understand and will close this PR shortly. I'm submitting it anyway to:

- ... have an easy bookmark to return to in case the above policy changes at any point in the future (and possibly gently nudge you to reconsider given that there is continuing interest in the project)
- ... contribute to the library of possible features that any future adoptive fork maintainer might harvest for inclusion
- ... model what this code change looks like so it's clearer to a few more people how to implement a simple feature like this
- ... help any other users interested enough in this feature to compile the code themselves
- ... help _myself_ keep track of this work for the next time I use Ghostwriter
- ... feel a sense of closure after working on this

I'm going to watch for a bit after submitting to see whether you have any triggers set up to run tests, and if so, I'll fix any failed tests before closing.

## Motivation

I'm not a fan of scrolling past the last line of a file into blank space, which Ghostwriter currently does; I like to be able to scroll all the way down and still easily see the entire last page of the file. In VSCode this is covered by a setting called "Scroll Beyond Last Line":

![image](https://user-images.githubusercontent.com/1559108/182276553-1edd6191-d38d-4141-abd5-6a7203f56c7e.png)

Atom went with the pithier "Scroll Past End":

![image](https://user-images.githubusercontent.com/1559108/182276939-407992d3-4f20-493f-b997-f1384f57d5aa.png)

## Changes

Now there's a "Scroll past end" checkbox in the General → Display section of the Ghostwriter preferences. It defaults to checked for backwards compatibility:

![image](https://user-images.githubusercontent.com/1559108/182277174-e121f472-5e5f-4fe6-ba65-1d2f86b13b7b.png)

If you uncheck it, then the end of the document won't scroll off-screen:

![image](https://user-images.githubusercontent.com/1559108/182277188-7416fcc7-c880-4342-8cc8-0cf78d5e15b8.png)

Fortunately this just amounted to exposing [QPlainTextEdit.setCenterOnScroll](https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QPlainTextEdit.html#PySide2.QtWidgets.PySide2.QtWidgets.QPlainTextEdit.setCenterOnScroll) in a user setting:

> This also allows the text edit to scroll below the end of the document.

I tried to follow the style of the existing code. I also included two changes that I needed to be able to compile it, presumably with a different version of QT than you're using:

- `qtTranslator` looks like it was renamed to `translator` but only one branch of an `#if` was updated, now both are
- `mouseEvent->globalPosition()` is `mouseEvent->globalPos()` on my system, so I added an `#if` with the same version check as the previous bullet point
