### PR TITLE
Fix build issues on macos 12.5

### DIFF
--- a/src/spelling/nsspellcheckerprovider.h
+++ b/src/spelling/nsspellcheckerprovider.h
@@ -37,7 +37,7 @@ public:
 	}
 
 	QStringList availableDictionaries() const;
-	AbstractDictionary* requestDictionary(const QString &language) const;
+	Dictionary* requestDictionary(const QString &language) const;
 
 	void setIgnoreNumbers(bool ignore);
 	void setIgnoreUppercase(bool ignore);

--- a/src/spelling/nsspellcheckerprovider.mm
+++ b/src/spelling/nsspellcheckerprovider.mm
@@ -140,7 +140,7 @@ QStringList NSSpellCheckerDictionary::suggestions(const QString &word) const
 
 void NSSpellCheckerDictionary::addToPersonal(const QString &word)
 {
-	DictionaryManager::instance().add(word);
+	DictionaryManager::instance()->add(word);
 }
 
 void NSSpellCheckerDictionary::addToSession(const QStringList &words)


### PR DESCRIPTION
I met building problems on macos and made the corresponding code changes to fix this issue
```shell
make: *** [build/release/dictionarymanager.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from src/spelling/nsspellcheckerprovider.mm:21:
src/spelling/nsspellcheckerprovider.h:40:2: error: unknown type name 'AbstractDictionary'
        AbstractDictionary* requestDictionary(const QString &language) const;
        ^
src/spelling/nsspellcheckerprovider.mm:143:31: error: member reference type 'ghostwriter::DictionaryManager *' is a pointer; did you mean to use '->'?
        DictionaryManager::instance().add(word);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
                                     ->
2 errors generated.
make: *** [build/release/nsspellcheckerprovider.o] Error 1
```
